### PR TITLE
handshake packet to parse auth plugin name up to first zero byte

### DIFF
--- a/src/packets.rs
+++ b/src/packets.rs
@@ -964,8 +964,8 @@ impl<'a> HandshakePacket<'a> {
                 (None, payload)
             };
         let auth_plugin_name = if capabilities.contains(CapabilityFlags::CLIENT_PLUGIN_AUTH) {
-            if payload[payload.len() - 1] == 0x00 {
-                Some(&payload[..payload.len() - 1])
+            if let Some(pos) = payload.iter().position(|&x| x == 0x00) {
+                Some(&payload[..pos])
             } else {
                 Some(payload)
             }


### PR DESCRIPTION
I've encountered an issue where mysql_async wasn't able to establish SSL connection with a database, because the name of auth plugin was parsed incorrectly (`UnknownAuthPlugin { name: "mysql_native_password\u{0}" }`). The problem here is that the handshake packet contains two leading zero bytes instead of only one or none. This is the server I've been using: https://github.com/facebook/mysql-5.6 but I am unable to provide detailed configuration for that server nor a repro in a more popular mysql server version.

I've noticed that the https://github.com/mysql/mysql-proxy as well as https://github.com/mysql/mysql-server parses the handshake auth plugin part a bit differently - [the latter](https://github.com/mysql/mysql-server/blob/124c7ab1d6f914637521fd4463a993aa73403513/sql/auth/sql_authentication.cc#L805) is using strcasecmp which compares strings up to the first `\0` and [the former](https://github.com/mysql/mysql-proxy/blob/ca6ad61af9088147a568a079c44d0d322f5bee59/src/network-mysqld-packet.c#L1256) simply looks for the first `\0` in an array of chars.

Both of those approaches work well when two leading zero bytes are send, so I am proposing to fix the mysql_common crate to look for the first `\0` when parsing auth plugin name instead of assuming there is only one or none `\0`.