### PR TITLE
Split Value::Float into 32 and 64 bit variants

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -68,11 +68,11 @@ pub trait WriteMysqlExt: WriteBytesExt {
                 self.write_u64::<LE>(x)?;
                 Ok(8)
             }
-            Value::F32(x) => {
+            Value::Float(x) => {
                 self.write_f32::<LE>(x)?;
                 Ok(8)
             }
-            Value::F64(x) => {
+            Value::Double(x) => {
                 self.write_f64::<LE>(x)?;
                 Ok(8)
             }

--- a/src/io.rs
+++ b/src/io.rs
@@ -68,7 +68,11 @@ pub trait WriteMysqlExt: WriteBytesExt {
                 self.write_u64::<LE>(x)?;
                 Ok(8)
             }
-            Value::Float(x) => {
+            Value::F32(x) => {
+                self.write_f32::<LE>(x)?;
+                Ok(8)
+            }
+            Value::F64(x) => {
                 self.write_f64::<LE>(x)?;
                 Ok(8)
             }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1323,10 +1323,10 @@ impl ComStmtExecuteRequestBuilder {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_LONGLONG);
                 self.set_unsigned(param_index);
             }
-            Value::F64(_) => {
+            Value::Double(_) => {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_DOUBLE);
             }
-            Value::F32(_) => {
+            Value::Float(_) => {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_FLOAT);
             }
             Value::Date(..) => {

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1323,8 +1323,11 @@ impl ComStmtExecuteRequestBuilder {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_LONGLONG);
                 self.set_unsigned(param_index);
             }
-            Value::Float(_) => {
+            Value::F64(_) => {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_DOUBLE);
+            }
+            Value::F32(_) => {
+                self.set_type(param_index, ColumnType::MYSQL_TYPE_FLOAT);
             }
             Value::Date(..) => {
                 self.set_type(param_index, ColumnType::MYSQL_TYPE_DATETIME);

--- a/src/value/convert/bigdecimal.rs
+++ b/src/value/convert/bigdecimal.rs
@@ -23,12 +23,12 @@ impl ConvIr<BigDecimal> for ParseIr<BigDecimal> {
                 value: Value::UInt(x),
                 output: x.into(),
             }),
-            Value::F32(x) => Ok(ParseIr {
-                value: Value::F32(x),
+            Value::Float(x) => Ok(ParseIr {
+                value: Value::Float(x),
                 output: x.into(),
             }),
-            Value::F64(x) => Ok(ParseIr {
-                value: Value::F64(x),
+            Value::Double(x) => Ok(ParseIr {
+                value: Value::Double(x),
                 output: x.into(),
             }),
             Value::Bytes(bytes) => match BigDecimal::parse_bytes(&*bytes, 10) {

--- a/src/value/convert/bigdecimal.rs
+++ b/src/value/convert/bigdecimal.rs
@@ -23,8 +23,12 @@ impl ConvIr<BigDecimal> for ParseIr<BigDecimal> {
                 value: Value::UInt(x),
                 output: x.into(),
             }),
-            Value::Float(x) => Ok(ParseIr {
-                value: Value::Float(x),
+            Value::F32(x) => Ok(ParseIr {
+                value: Value::F32(x),
+                output: x.into(),
+            }),
+            Value::F64(x) => Ok(ParseIr {
+                value: Value::F64(x),
                 output: x.into(),
             }),
             Value::Bytes(bytes) => match BigDecimal::parse_bytes(&*bytes, 10) {

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -361,14 +361,10 @@ impl ConvIr<u64> for ParseIr<u64> {
 impl ConvIr<f32> for ParseIr<f32> {
     fn new(v: Value) -> Result<ParseIr<f32>, FromValueError> {
         match v {
-            Value::Float(x)
-                if x >= f64::from(::std::f32::MIN) && x <= f64::from(::std::f32::MAX) =>
-            {
-                Ok(ParseIr {
-                    value: Value::Float(x),
-                    output: x as f32,
-                })
-            }
+            Value::F32(x) => Ok(ParseIr {
+                value: Value::F32(x),
+                output: x,
+            }),
             Value::Bytes(bytes) => {
                 let val = parse(&*bytes).ok();
                 match val {
@@ -393,8 +389,8 @@ impl ConvIr<f32> for ParseIr<f32> {
 impl ConvIr<f64> for ParseIr<f64> {
     fn new(v: Value) -> Result<ParseIr<f64>, FromValueError> {
         match v {
-            Value::Float(x) => Ok(ParseIr {
-                value: Value::Float(x),
+            Value::F64(x) => Ok(ParseIr {
+                value: Value::F64(x),
                 output: x,
             }),
             Value::Bytes(bytes) => {
@@ -955,13 +951,13 @@ impl From<u128> for Value {
 
 impl From<f32> for Value {
     fn from(x: f32) -> Value {
-        Value::Float(x.into())
+        Value::F32(x.into())
     }
 }
 
 impl From<f64> for Value {
     fn from(x: f64) -> Value {
-        Value::Float(x)
+        Value::F64(x)
     }
 }
 
@@ -1317,7 +1313,7 @@ mod tests {
 
         #[test]
         fn f32_roundtrip(n: f32) {
-            let val = Value::Float(n as f64);
+            let val = Value::F32(n);
             let val_bytes = Value::Bytes(n.to_string().into());
             assert_eq!(Value::from(from_value::<f32>(val.clone())), val);
             assert_eq!(Value::from(from_value::<f32>(val_bytes.clone())), val);
@@ -1325,7 +1321,7 @@ mod tests {
 
         #[test]
         fn f64_roundtrip(n: f64) {
-            let val = Value::Float(n);
+            let val = Value::F64(n);
             let val_bytes = Value::Bytes(n.to_string().into());
             assert_eq!(Value::from(from_value::<f64>(val.clone())), val);
             assert_eq!(Value::from(from_value::<f64>(val_bytes.clone())), val);

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -361,8 +361,8 @@ impl ConvIr<u64> for ParseIr<u64> {
 impl ConvIr<f32> for ParseIr<f32> {
     fn new(v: Value) -> Result<ParseIr<f32>, FromValueError> {
         match v {
-            Value::F32(x) => Ok(ParseIr {
-                value: Value::F32(x),
+            Value::Float(x) => Ok(ParseIr {
+                value: Value::Float(x),
                 output: x,
             }),
             Value::Bytes(bytes) => {
@@ -389,8 +389,8 @@ impl ConvIr<f32> for ParseIr<f32> {
 impl ConvIr<f64> for ParseIr<f64> {
     fn new(v: Value) -> Result<ParseIr<f64>, FromValueError> {
         match v {
-            Value::F64(x) => Ok(ParseIr {
-                value: Value::F64(x),
+            Value::Double(x) => Ok(ParseIr {
+                value: Value::Double(x),
                 output: x,
             }),
             Value::Bytes(bytes) => {
@@ -951,13 +951,13 @@ impl From<u128> for Value {
 
 impl From<f32> for Value {
     fn from(x: f32) -> Value {
-        Value::F32(x.into())
+        Value::Float(x.into())
     }
 }
 
 impl From<f64> for Value {
     fn from(x: f64) -> Value {
-        Value::F64(x)
+        Value::Double(x)
     }
 }
 
@@ -1313,7 +1313,7 @@ mod tests {
 
         #[test]
         fn f32_roundtrip(n: f32) {
-            let val = Value::F32(n);
+            let val = Value::Float(n);
             let val_bytes = Value::Bytes(n.to_string().into());
             assert_eq!(Value::from(from_value::<f32>(val.clone())), val);
             assert_eq!(Value::from(from_value::<f32>(val_bytes.clone())), val);
@@ -1321,7 +1321,7 @@ mod tests {
 
         #[test]
         fn f64_roundtrip(n: f64) {
-            let val = Value::F64(n);
+            let val = Value::Double(n);
             let val_bytes = Value::Bytes(n.to_string().into());
             assert_eq!(Value::from(from_value::<f64>(val.clone())), val);
             assert_eq!(Value::from(from_value::<f64>(val_bytes.clone())), val);

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -51,8 +51,8 @@ pub enum Value {
     Bytes(Vec<u8>),
     Int(i64),
     UInt(u64),
-    F32(f32),
-    F64(f64),
+    Float(f32),
+    Double(f64),
     /// year, month, day, hour, minutes, seconds, micro seconds
     Date(u16, u8, u8, u8, u8, u8, u32),
     /// is negative, days, hours, minutes, seconds, micro seconds
@@ -134,8 +134,8 @@ impl Value {
             Value::Bytes(x) => lenenc_int_len(x.len()) + x.len(),
             Value::Int(_) => 8,
             Value::UInt(_) => 8,
-            Value::F32(_) => 4,
-            Value::F64(_) => 8,
+            Value::Float(_) => 4,
+            Value::Double(_) => 8,
             Value::Date(0u16, 0u8, 0u8, 0u8, 0u8, 0u8, 0u32) => 1,
             Value::Date(_, _, _, 0u8, 0u8, 0u8, 0u32) => 5,
             Value::Date(_, _, _, _, _, _, 0u32) => 8,
@@ -151,8 +151,8 @@ impl Value {
             Value::NULL => "NULL".into(),
             Value::Int(x) => format!("{}", x),
             Value::UInt(x) => format!("{}", x),
-            Value::F32(x) => format!("{}", x),
-            Value::F64(x) => format!("{}", x),
+            Value::Float(x) => format!("{}", x),
+            Value::Double(x) => format!("{}", x),
             Value::Date(y, m, d, 0, 0, 0, 0) => format!("'{:04}-{:02}-{:02}'", y, m, d),
             Value::Date(y, m, d, h, i, s, 0) => {
                 format!("'{:04}-{:02}-{:02} {:02}:{:02}:{:02}'", y, m, d, h, i, s)
@@ -266,7 +266,7 @@ impl Value {
                 }
             }
             ColumnType::MYSQL_TYPE_FLOAT => Ok(Float(input.read_f32::<LE>()?.into())),
-            ColumnType::MYSQL_TYPE_DOUBLE => Ok(Float(input.read_f64::<LE>()?)),
+            ColumnType::MYSQL_TYPE_DOUBLE => Ok(Double(input.read_f64::<LE>()?)),
             ColumnType::MYSQL_TYPE_TIMESTAMP
             | ColumnType::MYSQL_TYPE_DATE
             | ColumnType::MYSQL_TYPE_DATETIME => {
@@ -367,8 +367,8 @@ impl fmt::Debug for Value {
             }
             Value::Int(ref val) => f.debug_tuple("Int").field(val).finish(),
             Value::UInt(ref val) => f.debug_tuple("UInt").field(val).finish(),
-            Value::F32(ref val) => f.debug_tuple("F32").field(val).finish(),
-            Value::F64(ref val) => f.debug_tuple("F64").field(val).finish(),
+            Value::Float(ref val) => f.debug_tuple("Float").field(val).finish(),
+            Value::Double(ref val) => f.debug_tuple("Double").field(val).finish(),
             Value::Date(y, m, d, 0, 0, 0, 0) => {
                 let format = format!("'{:04}-{:02}-{:02}'", y, m, d);
                 f.debug_tuple("Date").field(&format).finish()
@@ -433,8 +433,8 @@ mod test {
                 Value::Int(0xF0),
                 Value::Int(0xF000),
                 Value::Int(0xF0000000),
-                Value::F32(std::f32::MAX),
-                Value::F64(std::f64::MAX),
+                Value::Float(std::f32::MAX),
+                Value::Double(std::f64::MAX),
                 Value::NULL,
                 Value::Date(2019, 11, 27, 12, 30, 0, 123456),
                 Value::UInt(0xF000000000000000),
@@ -484,8 +484,8 @@ mod test {
                 Value::Int(0xF0),
                 Value::Int(0xF000),
                 Value::Int(0xF0000000),
-                Value::F32(std::f32::MAX),
-                Value::F64(std::f64::MAX),
+                Value::Float(std::f32::MAX),
+                Value::Double(std::f64::MAX),
                 Value::NULL,
                 Value::Date(2019, 11, 27, 12, 30, 0, 123456),
                 Value::UInt(0xF000000000000000),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -51,7 +51,8 @@ pub enum Value {
     Bytes(Vec<u8>),
     Int(i64),
     UInt(u64),
-    Float(f64),
+    F32(f32),
+    F64(f64),
     /// year, month, day, hour, minutes, seconds, micro seconds
     Date(u16, u8, u8, u8, u8, u8, u32),
     /// is negative, days, hours, minutes, seconds, micro seconds
@@ -133,7 +134,8 @@ impl Value {
             Value::Bytes(x) => lenenc_int_len(x.len()) + x.len(),
             Value::Int(_) => 8,
             Value::UInt(_) => 8,
-            Value::Float(_) => 8,
+            Value::F32(_) => 4,
+            Value::F64(_) => 8,
             Value::Date(0u16, 0u8, 0u8, 0u8, 0u8, 0u8, 0u32) => 1,
             Value::Date(_, _, _, 0u8, 0u8, 0u8, 0u32) => 5,
             Value::Date(_, _, _, _, _, _, 0u32) => 8,
@@ -149,7 +151,8 @@ impl Value {
             Value::NULL => "NULL".into(),
             Value::Int(x) => format!("{}", x),
             Value::UInt(x) => format!("{}", x),
-            Value::Float(x) => format!("{}", x),
+            Value::F32(x) => format!("{}", x),
+            Value::F64(x) => format!("{}", x),
             Value::Date(y, m, d, 0, 0, 0, 0) => format!("'{:04}-{:02}-{:02}'", y, m, d),
             Value::Date(y, m, d, h, i, s, 0) => {
                 format!("'{:04}-{:02}-{:02} {:02}:{:02}:{:02}'", y, m, d, h, i, s)
@@ -364,7 +367,8 @@ impl fmt::Debug for Value {
             }
             Value::Int(ref val) => f.debug_tuple("Int").field(val).finish(),
             Value::UInt(ref val) => f.debug_tuple("UInt").field(val).finish(),
-            Value::Float(ref val) => f.debug_tuple("Float").field(val).finish(),
+            Value::F32(ref val) => f.debug_tuple("F32").field(val).finish(),
+            Value::F64(ref val) => f.debug_tuple("F64").field(val).finish(),
             Value::Date(y, m, d, 0, 0, 0, 0) => {
                 let format = format!("'{:04}-{:02}-{:02}'", y, m, d);
                 f.debug_tuple("Date").field(&format).finish()
@@ -429,8 +433,8 @@ mod test {
                 Value::Int(0xF0),
                 Value::Int(0xF000),
                 Value::Int(0xF0000000),
-                Value::Float(std::f32::MAX as f64),
-                Value::Float(std::f64::MAX),
+                Value::F32(std::f32::MAX),
+                Value::F64(std::f64::MAX),
                 Value::NULL,
                 Value::Date(2019, 11, 27, 12, 30, 0, 123456),
                 Value::UInt(0xF000000000000000),
@@ -480,8 +484,8 @@ mod test {
                 Value::Int(0xF0),
                 Value::Int(0xF000),
                 Value::Int(0xF0000000),
-                Value::Float(std::f32::MAX as f64),
-                Value::Float(std::f64::MAX),
+                Value::F32(std::f32::MAX),
+                Value::F64(std::f64::MAX),
                 Value::NULL,
                 Value::Date(2019, 11, 27, 12, 30, 0, 123456),
                 Value::UInt(0xF000000000000000),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -265,7 +265,7 @@ impl Value {
                     Ok(Int(input.read_i64::<LE>()?))
                 }
             }
-            ColumnType::MYSQL_TYPE_FLOAT => Ok(Float(input.read_f32::<LE>()?.into())),
+            ColumnType::MYSQL_TYPE_FLOAT => Ok(Float(input.read_f32::<LE>()?)),
             ColumnType::MYSQL_TYPE_DOUBLE => Ok(Double(input.read_f64::<LE>()?)),
             ColumnType::MYSQL_TYPE_TIMESTAMP
             | ColumnType::MYSQL_TYPE_DATE


### PR DESCRIPTION
Casting between f32 and f64 can cause precision loss. I have a minimal reproduction here [in this repo](https://github.com/tomhoule/mysql-async-float-precision-loss-repro). This happens for us when writing and reading from `float4` columns. I haven't been able to find the proper place to test this, so there are no tests, but I manually confirmed that this fixes the issue in our case.

The naming of the variants is just an idea, I chose what rust users are probably most familiar with.

This is a breaking change, but I think it's pretty important to fix.