### PR TITLE
HandshakeResponse::parse

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,8 +10,8 @@ pub static MAX_PAYLOAD_LEN: usize = 16_777_215;
 pub static DEFAULT_MAX_ALLOWED_PACKET: usize = 4 * 1024 * 1024;
 pub static MIN_COMPRESS_LENGTH: usize = 50;
 
-pub static UTF8_GENERAL_CI: u16 = 33;
-pub static UTF8MB4_GENERAL_CI: u16 = 45;
+pub static UTF8_GENERAL_CI: u8 = 33;
+pub static UTF8MB4_GENERAL_CI: u8 = 45;
 
 bitflags! {
     /// MySql server status flags


### PR DESCRIPTION
I'm working on a Rust project that simulates the behaviour of MySQL Server (similar to [mysql-srv](https://github.com/jonhoo/msql-srv/)). It's been extremely useful to pull `rust_mysql_common` and use it to build and parse things for the MySQL protocol.

The current implementation of `HandshakeResponse` allows to build the response, but not to parse a response that is coming from the client. I'd like to suggest we add `parse` function to it.

This is a WIP draft mostly opened to seek feedback on the idea. I'd understand if crate authors would prefer to only include things that are useful for building a MySQL client, not MySQL server.