### PR TITLE
Remove dependency on deprecated `failure` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bitflags = "1"
 byteorder = "1"
 bytes = "0.5.2"
 chrono = { version = "0.4", features = ["serde"] }
-failure = "0.1.5"
 flate2 = { version = "1.0", default-features = false }
 lazy_static = "1"
 lexical = "5.2"

--- a/src/proto/codec/error.rs
+++ b/src/proto/codec/error.rs
@@ -6,7 +6,6 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use bitflags::_core::fmt::Formatter;
 use std::fmt;
 use std::io;
 


### PR DESCRIPTION
The `failure` crate is officially deprecated/unmaintained (see https://rustsec.org/advisories/RUSTSEC-2020-0036.html). This replaces its only use with a manual implementation of the `std::error::Error` trait where necessary.