### PR TITLE
Add BinlogDumpPacket and RegisterSlavePacket

### DIFF
--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1501,6 +1501,36 @@ impl Into<Vec<u8>> for BinlogDumpPacket {
     }
 }
 
+pub struct RegisterSlavePacket {
+    data: Vec<u8>,
+}
+
+impl RegisterSlavePacket {
+    pub fn new(server_id: u32) -> Self {
+        let mut buffer = Vec::new();
+        buffer.write_u32::<LE>(server_id).unwrap();
+        buffer.write_u8(0).unwrap();
+        buffer.write_u8(0).unwrap();
+        buffer.write_u8(0).unwrap();
+        buffer.write_u16::<LE>(0).unwrap();
+        buffer.write_u32::<LE>(0).unwrap();
+        buffer.write_u32::<LE>(0).unwrap();
+        RegisterSlavePacket { data: buffer }
+    }
+}
+
+impl AsRef<[u8]> for RegisterSlavePacket {
+    fn as_ref(&self) -> &[u8] {
+        &*self.data
+    }
+}
+
+impl Into<Vec<u8>> for RegisterSlavePacket {
+    fn into(self) -> Vec<u8> {
+        self.data
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1922,7 +1922,7 @@ mod test {
         let actual: Vec<u8> = RegisterSlavePacket::new(1).into();
         let expected: Vec<u8> = [
             0x01, 0x00, 0x00, 0x00, // server id
-            0x00, // slaves hostname leng
+            0x00, // slaves hostname len
             0x00, // slaves user len
             0x00, // salves password len
             0x00, 0x00, // slaves mysql port

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1536,7 +1536,8 @@ mod test {
     use super::{
         column_from_payload, parse_auth_more_data, parse_auth_switch_request, parse_err_packet,
         parse_handshake_packet, parse_local_infile_packet, parse_ok_packet, parse_stmt_packet,
-        AuthPlugin, BinlogDumpPacket, HandshakeResponse, OkPacketKind, SessionStateChange,
+        AuthPlugin, BinlogDumpPacket, HandshakeResponse, OkPacketKind, RegisterSlavePacket,
+        SessionStateChange,
     };
     use crate::constants::{
         CapabilityFlags, ColumnFlags, ColumnType, StatusFlags, UTF8_GENERAL_CI,
@@ -1895,7 +1896,7 @@ mod test {
     #[test]
     fn should_build_binlog_dump_packet() {
         let actual: Vec<u8> =
-            BinlogDumpPacket::new(123, Some("mysql-bin-changelog.123"), true, 1).into();
+            BinlogDumpPacket::new(Some("mysql-bin-changelog.123"), 123, true, 1).into();
         let expected: Vec<u8> = [
             0x7b, 0x00, 0x00, 0x00, // position
             0x01, 0x00, // flags
@@ -1906,11 +1907,27 @@ mod test {
         .to_vec();
         assert_eq!(expected, actual);
 
-        let actual: Vec<u8> = BinlogDumpPacket::new(0, None, false, 1).into();
+        let actual: Vec<u8> = BinlogDumpPacket::new(None, 0, false, 1).into();
         let expected: Vec<u8> = [
             0x00, 0x00, 0x00, 0x00, // position
             0x00, 0x00, // flags
             0x01, 0x00, 0x00, 0x00, // server id
+        ]
+        .to_vec();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_build_register_slave_packet() {
+        let actual: Vec<u8> = RegisterSlavePacket::new(1).into();
+        let expected: Vec<u8> = [
+            0x01, 0x00, 0x00, 0x00, // server id
+            0x00, // slaves hostname leng
+            0x00, // slaves user len
+            0x00, // salves password len
+            0x00, 0x00, // slaves mysql port
+            0x00, 0x00, 0x00, 0x00, // replication rank
+            0x00, 0x00, 0x00, 0x00, // master id
         ]
         .to_vec();
         assert_eq!(expected, actual);

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1477,15 +1477,21 @@ pub struct BinlogDumpPacket {
 }
 
 impl BinlogDumpPacket {
-    pub fn new(position: u32, file_name: Option<&str>, non_block: bool, server_id: u32) -> Self {
+    pub fn new(file_name: Option<&str>, position: u32, non_blocking: bool, server_id: u32) -> Self {
         let mut buffer = Vec::new();
         buffer.write_u32::<LE>(position).unwrap();
-        buffer.write_u16::<LE>(non_block as u16).unwrap();
+        buffer.write_u16::<LE>(non_blocking as u16).unwrap();
         buffer.write_u32::<LE>(server_id).unwrap();
         if let Some(file_name) = file_name {
             buffer.extend_from_slice(file_name.as_bytes());
         }
         BinlogDumpPacket { data: buffer }
+    }
+}
+
+impl AsRef<[u8]> for BinlogDumpPacket {
+    fn as_ref(&self) -> &[u8] {
+        &*self.data
     }
 }
 


### PR DESCRIPTION
Adding those packet definitions as per the docs:
- https://dev.mysql.com/doc/internals/en/com-binlog-dump.html for `BinlogDumpPacket`
- https://dev.mysql.com/doc/internals/en/com-register-slave.html for `RegisterSlavePacket`

I've tested it in a personal crate and confirm I'm able to get a binlog stream from the server with them! 