### PR TITLE
Drop dependency on twox-hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ sha2 = "0.9"
 smallvec = { version = "1.6.1", features = ["union", "write"] }
 thiserror = "1.0.24"
 time = { version = "0.2", default-features = false, features = ["std"] }
-twox-hash = "1"
 uuid = "0.8"
 serde = "1"
 serde_json = "1"

--- a/src/params.rs
+++ b/src/params.rs
@@ -6,8 +6,6 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use twox_hash::XxHash;
-
 use std::{
     collections::{
         hash_map::{Entry, Entry::Occupied},
@@ -15,7 +13,6 @@ use std::{
     },
     error::Error,
     fmt,
-    hash::BuildHasherDefault,
 };
 
 use crate::value::{convert::ToValue, Value};
@@ -40,7 +37,7 @@ impl Error for MissingNamedParameterError {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Params {
     Empty,
-    Named(HashMap<String, Value, BuildHasherDefault<XxHash>>),
+    Named(HashMap<String, Value>),
     Positional(Vec<Value>),
 }
 


### PR DESCRIPTION
twox-hash hasn't been keeping up with the dependency update cycle, and
so brings in an old version of the rand crate. I didn't see a compelling
reason to use XxHash over the default hash algorithm, so just remove it.