### PR TITLE
fix: incorrect auth_plugin_data length in HandshakePacket

### DIFF
--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1351,7 +1351,8 @@ impl MySerialize for HandshakePacket<'_> {
         buf.put_u8(
             self.scramble_2
                 .as_ref()
-                .map(|x| (x.len() + 8) as u8)
+                // +1 for the trailing 0x00
+                .map(|x| (x.len() + 8 + 1) as u8)
                 .unwrap_or_default(),
         );
         buf.put_slice(&[0_u8; 10][..]);


### PR DESCRIPTION
Hi, @blackbeam !
Thanks for maintaining this project!
I'm writing a simple MySQL proxy server for our product, and I use mysql_common serialization/deserialization methods to alter a few things in the initial handshake procedure.
I ran into quite strange behavior when responding with mysql_common-generated HandshakePacket: I'd specify `mysql_native_password` auth plugin in it, but a client would always respond with `caching_sha2_password` (default). After comparing my handshake packet with the one from the downstream service (while passing the same exact params to the HandshakePacket::new), I found only one difference: mysql_common would send auth_plugin_length one byte shorter.

<img width="1757" alt="Screen Shot 2021-10-29 at 11 18 39 AM" src="https://user-images.githubusercontent.com/2292499/139483509-6e8bcc43-3746-4071-8bb1-c56b2f1427c1.png">

I forked the project, added +1 and now my auth works as expected. I suspect that the missing one is for the trailing 0x00, that mysql_common adds after the `scrable2` param but doesn't account for it in the overall length.
