### PR TITLE
Trim zero terminator from nonce.

### DIFF
--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1511,6 +1511,10 @@ impl<'a> HandshakePacket<'a> {
     pub fn nonce(&self) -> Vec<u8> {
         let mut out = Vec::from(self.scramble_1_ref());
         out.extend_from_slice(self.scramble_2_ref().unwrap_or(&[][..]));
+
+        // Trim zero terminator. Fill with zeroes if nonce
+        // is somehow smaller than 20 bytes.
+        out.resize(20, 0);
         out
     }
 


### PR DESCRIPTION
rust-mysql-simple uses `nonce` to retrieve the nonce from a HandshakeResponse. Update nonce to be trimmed here so that
rust-mysql-simple can be updated to 0.28.