### PR TITLE
Update regex to `1.5.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ lexical = "6.0.1"
 num-bigint = { version = "0.4" }
 num-traits = { version = "0.2", features = ["i128"] }
 rand = "0.8.3"
-regex = "1"
+regex = "1.5.5"
 rust_decimal = { version = "1.0", optional = true }
 sha-1 = "0.10.0"
 sha2 = "0.10.0"


### PR DESCRIPTION
Updates regex to `1.5.5` as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)