### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/proto/codec/mod.rs
+++ b/src/proto/codec/mod.rs
@@ -75,16 +75,16 @@ pub fn compress(
         dst.reserve(7 + chunk.len());
 
         if compression != Compression::none() && chunk.len() >= MIN_COMPRESS_LENGTH {
-            unsafe {
+            
                 let mut encoder = ZlibEncoder::new(chunk, compression);
                 let mut read = 0;
                 loop {
                     dst.reserve(max(chunk.len().saturating_sub(read), 1));
                     let dst_buf = &mut dst.chunk_mut()[7 + read..];
-                    match encoder.read(&mut *slice_from_raw_parts_mut(
+                    match unsafe { encoder.read(&mut *slice_from_raw_parts_mut(
                         dst_buf.as_mut_ptr(),
                         dst_buf.len(),
-                    ))? {
+                    ))? } {
                         0 => break,
                         count => read += count,
                     }
@@ -93,8 +93,8 @@ pub fn compress(
                 dst.put_uint_le(read as u64, 3);
                 dst.put_u8(seq_id);
                 dst.put_uint_le(chunk.len() as u64, 3);
-                dst.advance_mut(read);
-            }
+                unsafe { dst.advance_mut(read) };
+            
         } else {
             dst.put_uint_le(chunk.len() as u64, 3);
             dst.put_u8(seq_id);
@@ -325,9 +325,9 @@ impl CompDecoder {
                         }
                         CompData::Compressed(needed, plain_len) => {
                             dst.reserve(plain_len.get());
+                            let mut decoder = ZlibDecoder::new(&src[..needed.get()]);
+                            let dst_buf = &mut dst.chunk_mut()[..plain_len.get()];
                             unsafe {
-                                let mut decoder = ZlibDecoder::new(&src[..needed.get()]);
-                                let dst_buf = &mut dst.chunk_mut()[..plain_len.get()];
                                 decoder.read_exact(&mut *slice_from_raw_parts_mut(
                                     dst_buf.as_mut_ptr(),
                                     dst_buf.len(),

--- a/src/proto/sync_framed.rs
+++ b/src/proto/sync_framed.rs
@@ -154,14 +154,14 @@ where
             } else {
                 match self.codec.decode(&mut self.in_buf, dst)? {
                     true => return Ok(true),
-                    false => unsafe {
+                    false => {
                         self.in_buf.reserve(1);
-                        match with_interrupt!(self.stream.read(&mut *slice_from_raw_parts_mut(
+                        match unsafe { with_interrupt!(self.stream.read(&mut *slice_from_raw_parts_mut(
                             self.in_buf.chunk_mut().as_mut_ptr(),
                             self.in_buf.chunk_mut().len()
-                        ))) {
+                        ))) } {
                             Ok(0) => self.eof = true,
-                            Ok(x) => self.in_buf.advance_mut(x),
+                            Ok(x) => unsafe { self.in_buf.advance_mut(x) },
                             Err(err) => return Err(From::from(err)),
                         }
                     },


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html