### PR TITLE
Switch from `sha-1` to `sha1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ num-traits = { version = "0.2", features = ["i128"] }
 rand = "0.8.3"
 regex = "1.5.5"
 rust_decimal = { version = "1.0", optional = true }
-sha-1 = "0.10.0"
+sha1 = "0.10.0"
 sha2 = "0.10.0"
 smallvec = { version = "1.6.1", features = ["union", "write"] }
 thiserror = "1.0.24"


### PR DESCRIPTION
The RustCrypto project recently got control of the crate name `sha1`. This
commit switches over to the new name; the old `sha-1` name is now deprecated.

Details: https://github.com/RustCrypto/hashes/pull/350