### PR TITLE
Add parsing from string for Sid(GTID)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         run: cargo fmt -- --check
       - name: Features subsets
         run: |
-          ruby -e "fs=['bigdecimal', 'bigdecimal03', 'chrono', 'rust_decimal', 'time', 'time03', 'uuid', 'frunk']; \
+          ruby -e "fs=['bigdecimal', 'bigdecimal03', 'chrono', 'rust_decimal', 'time', 'time03', 'frunk']; \
             (1..fs.length).each do |n| puts fs.combination(n).to_a.map {|x| x.join(\" \")}.join(\"\n\"); end" \
           | while read -r line; do \
             echo "$line" && cargo check --quiet --tests --no-default-features --features "flate2/zlib test $line"; \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ smallvec = { version = "1.6.1", features = ["union", "write"] }
 thiserror = "1.0.24"
 time = { version = "0.2", default-features = false, features = ["std"], optional = true }
 time03 = { package = "time", version = "0.3", default-features = false, features = ["parsing"], optional = true }
-uuid = { version = "1", optional = true }
+uuid = "1"
 saturating = "0.1"
 serde = "1"
 serde_json = "1"
@@ -67,7 +67,6 @@ default = [
     "bigdecimal03",
     "rust_decimal",
     "time03",
-    "uuid",
     "frunk",
 ]
 test = []

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -12,10 +12,10 @@ use regex::bytes::Regex;
 use smallvec::SmallVec;
 use uuid::Uuid;
 
+use std::str::FromStr;
 use std::{
     borrow::Cow, cmp::max, collections::HashMap, convert::TryFrom, fmt, io, marker::PhantomData,
 };
-use std::str::FromStr;
 
 use crate::{
     constants::{
@@ -2577,14 +2577,14 @@ impl<'de> MyDeserialize<'de> for ComBinlogDump<'de> {
     }
 }
 
-/// Interval. Stored within [`Sid`]
+/// GnoInterval. Stored within [`Sid`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Interval {
+pub struct GnoInterval {
     start: RawInt<LeU64>,
     end: RawInt<LeU64>,
 }
 
-impl Interval {
+impl GnoInterval {
     /// Creates a new interval.
     pub fn new(start: u64, end: u64) -> Self {
         Self {
@@ -2592,16 +2592,32 @@ impl Interval {
             end: RawInt::new(end),
         }
     }
+    /// Checks if the [start, end) interval is valid and creates it.
+    pub fn check_and_new(start: u64, end: u64) -> io::Result<Self> {
+        if start >= end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("start({}) >= end({}) in GnoInterval", start, end),
+            ));
+        }
+        if start == 0 || end == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Gno can't be zero",
+            ));
+        }
+        Ok(Self::new(start, end))
+    }
 }
 
-impl MySerialize for Interval {
+impl MySerialize for GnoInterval {
     fn serialize(&self, buf: &mut Vec<u8>) {
         self.start.serialize(&mut *buf);
         self.end.serialize(&mut *buf);
     }
 }
 
-impl<'de> MyDeserialize<'de> for Interval {
+impl<'de> MyDeserialize<'de> for GnoInterval {
     const SIZE: Option<usize> = Some(16);
     type Ctx = ();
 
@@ -2613,37 +2629,38 @@ impl<'de> MyDeserialize<'de> for Interval {
     }
 }
 
-/// Length of a sid in `COM_BINLOG_DUMP_GTID` command packet.
-pub const SID_LEN: usize = 16;
+/// Length of a Uuid in `COM_BINLOG_DUMP_GTID` command packet.
+pub const UUID_LEN: usize = 16;
 
-/// SID is a part of the `COM_BINLOG_DUMP_GTID` command.
+/// SID is a part of the `COM_BINLOG_DUMP_GTID` command. It's a GtidSet whose
+/// has only one Uuid.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Sid<'a> {
-    sid: [u8; SID_LEN],
-    intervals: Seq<'a, Interval, LeU64>,
+    uuid: [u8; UUID_LEN],
+    intervals: Seq<'a, GnoInterval, LeU64>,
 }
 
 impl<'a> Sid<'a> {
     /// Creates a new instance.
-    pub fn new(sid: [u8; SID_LEN]) -> Self {
+    pub fn new(uuid: [u8; UUID_LEN]) -> Self {
         Self {
-            sid,
+            uuid,
             intervals: Default::default(),
         }
     }
 
-    /// Returns the `sid` field value.
-    pub fn sid(&self) -> [u8; SID_LEN] {
-        self.sid
+    /// Returns the `uuid` field value.
+    pub fn uuid(&self) -> [u8; UUID_LEN] {
+        self.uuid
     }
 
     /// Returns the `intervals` field value.
-    pub fn intervals(&self) -> &[Interval] {
+    pub fn intervals(&self) -> &[GnoInterval] {
         &self.intervals[..]
     }
 
-    /// Appends an interval to this block.
-    pub fn with_interval(mut self, interval: Interval) -> Self {
+    /// Appends an GnoInterval to this block.
+    pub fn with_interval(mut self, interval: GnoInterval) -> Self {
         let mut intervals = self.intervals.0.into_owned();
         intervals.push(interval);
         self.intervals = Seq::new(intervals);
@@ -2651,14 +2668,14 @@ impl<'a> Sid<'a> {
     }
 
     /// Sets the `intevals` value for this block.
-    pub fn with_intervals(mut self, intervals: Vec<Interval>) -> Self {
+    pub fn with_intervals(mut self, intervals: Vec<GnoInterval>) -> Self {
         self.intervals = Seq::new(intervals);
         self
     }
 
     fn len(&self) -> u64 {
         use saturating::Saturating as S;
-        let mut len = S(SID_LEN as u64); // SID
+        let mut len = S(UUID_LEN as u64); // SID
         len += S(8); // n_intervals
         len += S((self.intervals.len() * 16) as u64);
         len.0
@@ -2667,7 +2684,7 @@ impl<'a> Sid<'a> {
 
 impl MySerialize for Sid<'_> {
     fn serialize(&self, buf: &mut Vec<u8>) {
-        self.sid.serialize(&mut *buf);
+        self.uuid.serialize(&mut *buf);
         self.intervals.serialize(buf);
     }
 }
@@ -2678,7 +2695,7 @@ impl<'de> MyDeserialize<'de> for Sid<'de> {
 
     fn deserialize((): Self::Ctx, buf: &mut ParseBuf<'de>) -> io::Result<Self> {
         Ok(Self {
-            sid: buf.parse(())?,
+            uuid: buf.parse(())?,
             intervals: buf.parse(())?,
         })
     }
@@ -2691,52 +2708,45 @@ impl Sid<'_> {
 
     fn parse_interval_num(to_parse: &str, full: &str) -> Result<u64, io::Error> {
         let n: u64 = to_parse.parse().map_err(|e| {
-            Sid::wrap_err(
-                format!("invalid interval format: {}, error: {}", full, e)
-            )
+            Sid::wrap_err(format!(
+                "invalid GnoInterval format: {}, error: {}",
+                full, e
+            ))
         })?;
-        if n == 0 {
-            return Err(Sid::wrap_err(
-                format!("invalid interval format: {}, error: interval can't contain 0", full)
-            ));
-        }
         Ok(n)
     }
 }
-
 
 impl<'a> FromStr for Sid<'a> {
     type Err = io::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (uuid, intervals) = s.split_once(':').ok_or_else(|| {
-            Sid::wrap_err(format!("invalid sid format: {}", s))
-        })?;
-        let uuid = Uuid::parse_str(uuid).map_err(|e| {
-            Sid::wrap_err(format!("invalid uuid format: {}, error: {}", s, e))
-        })?;
+        let (uuid, intervals) = s
+            .split_once(':')
+            .ok_or_else(|| Sid::wrap_err(format!("invalid sid format: {}", s)))?;
+        let uuid = Uuid::parse_str(uuid)
+            .map_err(|e| Sid::wrap_err(format!("invalid uuid format: {}, error: {}", s, e)))?;
         let intervals = intervals
             .split(':')
             .map(|interval| {
                 let nums = interval.split('-').collect::<Vec<_>>();
                 if nums.len() != 1 && nums.len() != 2 {
-                    return Err(
-                        Sid::wrap_err(format!("invalid interval format: {}", s))
-                    )
+                    return Err(Sid::wrap_err(format!("invalid GnoInterval format: {}", s)));
                 }
                 if nums.len() == 1 {
-                    let start=  Sid::parse_interval_num(nums[0], s)?;
-                    Ok(Interval::new(start, start+1))
+                    let start = Sid::parse_interval_num(nums[0], s)?;
+                    let interval = GnoInterval::check_and_new(start, start + 1)?;
+                    Ok(interval)
                 } else {
                     let start = Sid::parse_interval_num(nums[0], s)?;
                     let end = Sid::parse_interval_num(nums[1], s)?;
-                    // TODO: check that start >= end will cause error in MySQL?
-                    Ok(Interval::new(start, end+1))
+                    let interval = GnoInterval::check_and_new(start, end + 1)?;
+                    Ok(interval)
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
-            sid: *uuid.as_bytes(),
+            uuid: *uuid.as_bytes(),
             intervals: Seq::new(intervals),
         })
     }
@@ -3074,7 +3084,7 @@ mod test {
             for i in 0..n_sid_blocks {
                 let mut block = Sid::new([i as u8; 16]);
                 for j in 0..i {
-                    block = block.with_interval(Interval::new(i, j));
+                    block = block.with_interval(GnoInterval::new(i, j));
                 }
                 sids.push(block);
             }
@@ -3512,14 +3522,14 @@ mod test {
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:23";
         let sid = input.parse::<Sid>().unwrap();
         let expected_sid = Uuid::parse_str("3E11FA47-71CA-11E1-9E33-C80AA9429562").unwrap();
-        assert_eq!(sid.sid, *expected_sid.as_bytes());
+        assert_eq!(sid.uuid, *expected_sid.as_bytes());
         assert_eq!(sid.intervals.len(), 1);
         assert_eq!(sid.intervals[0].start.0, 23);
         assert_eq!(sid.intervals[0].end.0, 24);
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:10-15";
         let sid = input.parse::<Sid>().unwrap();
-        assert_eq!(sid.sid, *expected_sid.as_bytes());
+        assert_eq!(sid.uuid, *expected_sid.as_bytes());
         assert_eq!(sid.intervals.len(), 2);
         assert_eq!(sid.intervals[0].start.0, 1);
         assert_eq!(sid.intervals[0].end.0, 6);
@@ -3528,18 +3538,25 @@ mod test {
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562";
         let e = input.parse::<Sid>().unwrap_err();
-        assert_eq!(e.to_string(), "invalid sid format: 3E11FA47-71CA-11E1-9E33-C80AA9429562".to_string());
+        assert_eq!(
+            e.to_string(),
+            "invalid sid format: 3E11FA47-71CA-11E1-9E33-C80AA9429562".to_string()
+        );
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:10-15:20-";
         let e = input.parse::<Sid>().unwrap_err();
-        assert_eq!(e.to_string(), "invalid interval format: 3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:10-15:20-, error: cannot parse integer from empty string".to_string());
+        assert_eq!(e.to_string(), "invalid GnoInterval format: 3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:10-15:20-, error: cannot parse integer from empty string".to_string());
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:1aaa";
         let e = input.parse::<Sid>().unwrap_err();
-        assert_eq!(e.to_string(), "invalid interval format: 3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:1aaa, error: invalid digit found in string".to_string());
+        assert_eq!(e.to_string(), "invalid GnoInterval format: 3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:1aaa, error: invalid digit found in string".to_string());
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:0-3";
         let e = input.parse::<Sid>().unwrap_err();
-        assert_eq!(e.to_string(), "invalid interval format: 3E11FA47-71CA-11E1-9E33-C80AA9429562:0-3, error: interval can't contain 0".to_string());
+        assert_eq!(e.to_string(), "Gno can't be zero".to_string());
+
+        let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:4-3";
+        let e = input.parse::<Sid>().unwrap_err();
+        assert_eq!(e.to_string(), "start(4) >= end(4) in GnoInterval".to_string());
     }
 }

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -3557,6 +3557,9 @@ mod test {
 
         let input = "3E11FA47-71CA-11E1-9E33-C80AA9429562:4-3";
         let e = input.parse::<Sid>().unwrap_err();
-        assert_eq!(e.to_string(), "start(4) >= end(4) in GnoInterval".to_string());
+        assert_eq!(
+            e.to_string(),
+            "start(4) >= end(4) in GnoInterval".to_string()
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

It's a lot of parsing work to do before start a GTID-based binlog stream, so I implemented `FromStr` for `Sid`. ref https://dev.mysql.com/doc/refman/8.0/en/replication-gtids-concepts.html

And I just start coding in rust some days ago, feel free to comment on my code :smile: 

BTW, I have some questions:
1. Why this structure is called `Sid` rather than GTID or uuid_set as in doc?
2. Can I add more check to other building functions? In order to avoid "ERROR 1774 (HY000): Malformed GTID specification" we can find the error when build it
3. I hope I can also add a GTIDSet struct to directly parse `2174B383-5441-11E8-B90A-C80AA9429562:1-3, 24DA167-0C0C-11E8-8442-00059A3C7B00:1-19`. What's about naming of it?