### PR TITLE
Implement FromValue for chrono NaiveTime

### DIFF
--- a/src/value/convert/chrono.rs
+++ b/src/value/convert/chrono.rs
@@ -26,6 +26,11 @@ impl FromValue for NaiveDate {
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
+impl FromValue for NaiveTime {
+    type Intermediate = ParseIr<NaiveTime>;
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 impl FromValue for NaiveDateTime {
     type Intermediate = ParseIr<NaiveDateTime>;
 }


### PR DESCRIPTION
Upgrading from 0.29.2 to 0.30.1 caused compilation issues with getting a NaiveTime from a row, e.g.:

```
let val: Option<NaiveTime> =
    row.get_opt(col_idx).expect("row value should exist")?;
```

errors with the following:

```
    |
606 |                         row.get_opt(col_idx).expect("row value should exist")?;
    |                             ^^^^^^^ the trait `mysql_async::prelude::FromValue` is not implemented for `NaiveTime`
    |
    = help: the following other types implement trait `mysql_async::prelude::FromValue`:
              Cow<'static, [u8]>
              Cow<'static, str>
              Deserialized<T>
              NaiveDate
              NaiveDateTime
              Vec<u8>
              [u8; N]
              bigdecimal::BigDecimal
            and 24 others
    = note: required for `std::option::Option<NaiveTime>` to implement `mysql_async::prelude::FromValue`
note: required by a bound in `mysql_async::Row::get_opt`
   --> /Users/sean/.cargo/registry/src/github.com-1ecc6299db9ec823/mysql_common-0.30.1/src/row/mod.rs:116:12
    |
116 |         T: FromValue,
    |            ^^^^^^^^^ required by this bound in `Row::get_opt`
```

This PR just adds that impl.