### PR TITLE
Fix mgf1 panic in 32bit env

### DIFF
--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -79,7 +79,7 @@ impl<T> Pkcs1OaepPadding<T> {
     ///
     /// It will use SHA-1 as a hash function.
     fn mgf1(seed: &[u8], len: usize) -> Vec<u8> {
-        if len > 2usize.pow(32) * Self::HASH_LEN {
+        if len as u64 > 2u64.pow(32) * Self::HASH_LEN as u64 {
             panic!("mask too long");
         }
 


### PR DESCRIPTION
In an 32-bit addressing space environment, usize is 4 bytes, which is not large enough to perform `2^32 * HASH_LEN` thus will trigger a panic. This PR fixes this problem by converting all the numbers to u64 before doing the comparison.