### PR TITLE
Bump bitflags dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bigdecimal02 = { package = "bigdecimal", version = "0.2", features = [
     "serde",
 ], optional = true }
 bigdecimal = { version = "0.3", optional = true }
-bitflags = "2"
+bitflags = "2.3"
 bitvec = "1.0"
 byteorder = "1"
 bytes = "1.0"


### PR DESCRIPTION
I tried adding a dependency on mysql_async to an existing project, and I'm getting an error

```
unresolved import `bitflags::Flags` no `Flags` in the root
```

coming from mysql_common-0.30.6/src/misc/raw/flags.rs

which I think is because mysql_common has a dependency on bitflags = ^2.0.0. My Cargo.lock file is choosing version 2.2.1 (because i was already using it for something else).

However, mysql_common requires the `Flags` trait which was added in 2.3.0. If I am understanding the package management correctly, mysql_common should depend on the version of bitflags that contains all features it uses.