### PR TITLE
Use a more correct crate for int parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 mysql-common-derive = { path = "derive", version = "0.30.2", optional = true }
+btoi = "0.4.3"
 
 [dev-dependencies]
 proptest = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ crc32fast = "1.2"
 flate2 = { version = "1.0", default-features = false }
 frunk = { version = "0.4", optional = true }
 lazy_static = "1"
-lexical = "6.0"
 num-bigint = { version = "0.4" }
 num-traits = { version = "0.2", features = ["i128"] }
 rand = "0.8"

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -41,7 +41,7 @@ pub(crate) fn unexpected_buf_eof() -> io::Error {
 /// It'll return `(0, 0, 0)` in case of error.
 pub fn split_version<T: AsRef<[u8]>>(version_str: T) -> (u8, u8, u8) {
     let bytes = version_str.as_ref();
-    split_version_inner(bytes).unwrap_or((0,0,0))
+    split_version_inner(bytes).unwrap_or((0, 0, 0))
 }
 
 // Split into its own function for two reasons:

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -41,26 +41,28 @@ pub(crate) fn unexpected_buf_eof() -> io::Error {
 /// It'll return `(0, 0, 0)` in case of error.
 pub fn split_version<T: AsRef<[u8]>>(version_str: T) -> (u8, u8, u8) {
     let bytes = version_str.as_ref();
-    let mut offset = 0;
-    let mut nums = [0_u8; 3];
-    for i in 0..=2 {
-        match lexical::parse_partial::<u8, _>(&bytes[offset..]) {
-            Ok((x, count))
-                if count > 0
-                    && (i != 0
-                        || (bytes.len() > offset + count && bytes[offset + count] == b'.')) =>
-            {
-                offset += count + 1;
-                nums[i] = x;
-            }
-            _ => {
-                nums = [0_u8; 3];
-                break;
-            }
-        }
-    }
+    split_version_inner(bytes).unwrap_or((0,0,0))
+}
 
-    (nums[0], nums[1], nums[2])
+// Split into its own function for two reasons:
+// 1. Generic function will be instantiated for every type, increasing code size
+// 2. It allows using Option and ? operator without breaking public API
+fn split_version_inner(input: &[u8]) -> Option<(u8, u8, u8)> {
+    let mut nums = [0_u8; 3];
+    let mut iter = input.split(|c| *c == b'.');
+    for (i, chunk) in (&mut iter).take(2).enumerate() {
+        nums[i] = btoi::btoi(chunk).ok()?;
+    }
+    // allow junk at the end of the final part of the version
+    let chunk_with_junk = iter.next()?;
+    let end_of_digits = chunk_with_junk.iter().position(|c| *c < b'0' || *c > b'9');
+    let chunk = match end_of_digits {
+        Some(pos) => &chunk_with_junk[..pos],
+        None => chunk_with_junk,
+    };
+    nums[2] = btoi::btoi(chunk).ok()?;
+
+    Some((nums[0], nums[1], nums[2]))
 }
 
 #[cfg(test)]

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -76,5 +76,7 @@ mod tests {
         assert_eq!((0, 0, 0), split_version("100.200.300foo"));
         assert_eq!((0, 0, 0), split_version("100.200foo"));
         assert_eq!((0, 0, 0), split_version("1,2.3"));
+        assert_eq!((0, 0, 0), split_version("1"));
+        assert_eq!((0, 0, 0), split_version("1.2"));
     }
 }

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -7,7 +7,7 @@
 // modified, or distributed except according to those terms.
 
 use bytes::BufMut;
-use lexical::parse;
+use btoi::btoi;
 use regex::bytes::Regex;
 use smallvec::SmallVec;
 use uuid::Uuid;
@@ -1552,9 +1552,9 @@ impl<'a> HandshakePacket<'a> {
             .map(|captures| {
                 // Should not panic because validated with regex
                 (
-                    parse::<u16, _>(captures.get(1).unwrap().as_bytes()).unwrap(),
-                    parse::<u16, _>(captures.get(2).unwrap().as_bytes()).unwrap(),
-                    parse::<u16, _>(captures.get(3).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(1).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(2).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(3).unwrap().as_bytes()).unwrap(),
                 )
             })
     }
@@ -1566,9 +1566,9 @@ impl<'a> HandshakePacket<'a> {
             .map(|captures| {
                 // Should not panic because validated with regex
                 (
-                    parse::<u16, _>(captures.get(1).unwrap().as_bytes()).unwrap(),
-                    parse::<u16, _>(captures.get(2).unwrap().as_bytes()).unwrap(),
-                    parse::<u16, _>(captures.get(3).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(1).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(2).unwrap().as_bytes()).unwrap(),
+                    btoi::<u16>(captures.get(3).unwrap().as_bytes()).unwrap(),
                 )
             })
     }

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -6,8 +6,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use bytes::BufMut;
 use btoi::btoi;
+use bytes::BufMut;
 use regex::bytes::Regex;
 use smallvec::SmallVec;
 use uuid::Uuid;

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -6,6 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use btoi::btoi;
 use lexical::parse;
 use num_traits::ToPrimitive;
 use regex::bytes::Regex;
@@ -185,7 +186,7 @@ macro_rules! impl_from_value_num {
                     Value::UInt(x) => $ty::try_from(x)
                         .map(ParseIrOpt::Ready)
                         .map_err(|_| FromValueError(Value::UInt(x))),
-                    Value::Bytes(bytes) => match parse(&*bytes) {
+                    Value::Bytes(bytes) => match btoi(&*bytes) {
                         Ok(x) => Ok(ParseIrOpt::Parsed(x, Value::Bytes(bytes))),
                         _ => Err(FromValueError(Value::Bytes(bytes))),
                     },


### PR DESCRIPTION
This switches integer parsing from `lexical` to `btoi` crate.

This necessitated rewriting the version parsing function, which is now more robust - it correctly rejects some inputs that made the previous implementation panic.

## Motivation

[`lexical` sometimes returns incorrect results instead of an error](https://github.com/Alexhuszagh/rust-lexical/issues/105) when the input is too large for the provided type. This is the primary motivation for this change.

`lexical` also has [soundness issues](https://rustsec.org/advisories/RUSTSEC-2023-0055.html) and appears to be unmaintained. By contrast `btoi` is 100% safe code so it will never have these kinds of issues.

I kept `lexical` around for parsing floats because the standard library does not expose an API to convert from `&[u8]` to floats without going through a `&str` first, which would incur some performance overhead. I can convert those too if you wish.