### PR TITLE
Add the capability to temporarily disable checksum verification.

### DIFF
--- a/src/binlog/events/format_description_event.rs
+++ b/src/binlog/events/format_description_event.rs
@@ -216,6 +216,9 @@ impl<'a> FormatDescriptionEvent<'a> {
     pub fn footer(&self) -> BinlogEventFooter {
         self.footer
     }
+    pub fn footer_mut(&mut self) -> &mut BinlogEventFooter {
+        &mut self.footer
+    }
 
     /// Returns a parsed MySql version.
     pub fn split_version(&self) -> (u8, u8, u8) {


### PR DESCRIPTION
MySQL always writes TRANSACTION_PAYLOAD_EVENT inner event without the 4 bytes checksum. Attempting to read the checksum with an already established EventStreamReader will fail:

Error: Custom { kind: UnexpectedEof, error: "can't parse: buf doesn't have enough data" }

Having a separate EventStreamReader for the TRANSACTION_PAYLOAD_EVENT requires extra logic as the table map event(tme) will be split across different objects.
This commit adds a new flag to EventStreamReader to disable checksum reading without having to change the original algorithm. Tests have been enhanced to utilize the new flag on the already-established EventStreamReader from binlog reader.