### PR TITLE
Add packets for `caching_sha2_password` public key retrieval

### DIFF
--- a/src/packets/caching_sha2_password.rs
+++ b/src/packets/caching_sha2_password.rs
@@ -11,8 +11,10 @@ define_header!(
     0x02
 );
 
-/// A request for a public RSA key, used by some authentication mechanisms
-/// to add a layer of protection to an unsecured channel.
+/// A client request for a server public RSA key, used by some authentication mechanisms
+/// to add a layer of protection to an unsecured channel (see [`PublicKeyResponse`]).
+///
+/// [`PublicKeyResponse`]: crate::packets::PublicKeyResponse
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PublicKeyRequest {
     __header: PublicKeyRequestHeader,

--- a/src/packets/caching_sha2_password.rs
+++ b/src/packets/caching_sha2_password.rs
@@ -1,0 +1,75 @@
+use std::io;
+
+use crate::{
+    io::ParseBuf,
+    proto::{MyDeserialize, MySerialize},
+};
+
+define_header!(
+    PublicKeyRequestHeader,
+    InvalidPublicKeyRequest("Invalid PublicKeyRequest header"),
+    0x02
+);
+
+/// A request for a public RSA key, used by some authentication mechanisms
+/// to add a layer of protection to an unsecured channel.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PublicKeyRequest {
+    __header: PublicKeyRequestHeader,
+}
+
+impl PublicKeyRequest {
+    pub fn new() -> Self {
+        Self {
+            __header: PublicKeyRequestHeader::new(),
+        }
+    }
+}
+
+impl<'de> MyDeserialize<'de> for PublicKeyRequest {
+    const SIZE: Option<usize> = None;
+    type Ctx = ();
+
+    fn deserialize((): Self::Ctx, buf: &mut ParseBuf<'de>) -> io::Result<Self> {
+        Ok(Self {
+            __header: buf.parse(())?,
+        })
+    }
+}
+
+impl MySerialize for PublicKeyRequest {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        self.__header.serialize(&mut *buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        io::ParseBuf,
+        packets::caching_sha2_password::PublicKeyRequest,
+        proto::{MyDeserialize, MySerialize},
+    };
+
+    #[test]
+    fn should_parse_rsa_public_key_request_packet() {
+        const RSA_PUBLIC_KEY_REQUEST: &[u8] = b"\x02";
+
+        let public_rsa_key_request =
+            PublicKeyRequest::deserialize((), &mut ParseBuf(RSA_PUBLIC_KEY_REQUEST));
+
+        assert!(public_rsa_key_request.is_ok());
+    }
+
+    #[test]
+    fn should_build_rsa_public_key_request_packet() {
+        let rsa_public_key_request = PublicKeyRequest::new();
+
+        let mut actual = Vec::new();
+        rsa_public_key_request.serialize(&mut actual);
+
+        let expected: Vec<u8> = [0x02].to_vec();
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -54,13 +54,13 @@ macro_rules! define_header {
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
         #[error($msg)]
         pub struct $err;
-        pub type $name = ConstU8<$err, $val>;
+        pub type $name = crate::misc::raw::int::ConstU8<$err, $val>;
     };
     ($name:ident, $cmd:ident, $err:ident) => {
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
         #[error("Invalid header for {}", stringify!($cmd))]
         pub struct $err;
-        pub type $name = ConstU8<$err, { Command::$cmd as u8 }>;
+        pub type $name = crate::misc::raw::int::ConstU8<$err, { Command::$cmd as u8 }>;
     };
 }
 

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1249,7 +1249,9 @@ define_header!(
     0x01
 );
 
-/// A response containing a public RSA key for authentication protection.
+/// A server response to a [`PublicKeyRequest`] containing a public RSA key for authentication protection.
+///
+/// [`PublicKeyRequest`]: crate::packets::caching_sha2_password::PublicKeyRequest
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PublicKeyResponse<'a> {
     __header: PublicKeyResponseHeader,


### PR DESCRIPTION
# Situation
We were trying to parse packets associated with public key requests/responses when using`caching_sha2_password` authentication. However, we don't believe that these packet types exist yet.

# Target
Allow packet parsing of public key requests and responses for `caching_sha2_password` authentication.

# Proposal
1. Create a new module to house details specific to `caching_sha2_password` authentication. We have a subsequent addition that is also `caching_sha2_password`-specific.
2. Introduce a packet to represent a public-key request for `caching_sha2_password`. Note that while this is similar to the one used for `sha256_password`, it has a different packet identifier.
3. Introduce a packet to represent a public-key response. This is shared between both `caching_sha2_password` and `sha256_password`, so it is excluded from the `caching_sha2_password` module.