### PR TITLE
fix: update MariaDB version regex to make the version hack optional

### DIFF
--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -45,7 +45,7 @@ use self::session_state_change::SessionStateChange;
 
 lazy_static::lazy_static! {
     static ref MARIADB_VERSION_RE: Regex =
-        Regex::new(r"^5.5.5-(\d{1,2})\.(\d{1,2})\.(\d{1,3})-MariaDB").unwrap();
+        Regex::new(r"^(?:5.5.5-)?(\d{1,2})\.(\d{1,2})\.(\d{1,3})-MariaDB").unwrap();
     static ref VERSION_RE: Regex = Regex::new(r"^(\d{1,2})\.(\d{1,2})\.(\d{1,3})(.*)").unwrap();
 }
 


### PR DESCRIPTION
Closes https://github.com/blackbeam/rust_mysql_common/issues/124

Credits to https://github.com/Weakky for this, I thought I could me it a PR to make it easier to be fixed.

Here is the explanation from https://regex101.com/ - the MariaDB version hack `5.5.5-` is now optional and a non capturing group.
<img width="719" alt="Screenshot 2024-02-13 at 11 09 36" src="https://github.com/blackbeam/rust_mysql_common/assets/1328733/edd8ac54-de50-476b-9934-cd4deff66252">
