### PR TITLE
Expose a flags() method on RowsEventData to read corresponding event flags

### DIFF
--- a/src/binlog/events/delete_rows_event.rs
+++ b/src/binlog/events/delete_rows_event.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -48,6 +48,11 @@ impl<'a> DeleteRowsEvent<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/delete_rows_event_v1.rs
+++ b/src/binlog/events/delete_rows_event_v1.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -47,6 +47,11 @@ impl<'a> DeleteRowsEventV1<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/mod.rs
+++ b/src/binlog/events/mod.rs
@@ -53,8 +53,8 @@ use std::{
 
 use super::{
     consts::{
-        BinlogChecksumAlg, BinlogVersion, EventFlags, EventType, UnknownChecksumAlg,
-        UnknownEventType,
+        BinlogChecksumAlg, BinlogVersion, EventFlags, EventType, RowsEventFlags,
+        UnknownChecksumAlg, UnknownEventType,
     },
     misc::LimitWrite,
     BinlogCtx, BinlogEvent,
@@ -791,6 +791,19 @@ impl<'a> RowsEventData<'a> {
             RowsEventData::UpdateRowsEvent(ev) => ev.rows_data(),
             RowsEventData::DeleteRowsEvent(ev) => ev.rows_data(),
             RowsEventData::PartialUpdateRowsEvent(ev) => ev.rows_data(),
+        }
+    }
+
+    /// Returns event flags.
+    pub fn flags(&self) -> RowsEventFlags {
+        match self {
+            RowsEventData::WriteRowsEventV1(ev) => ev.flags(),
+            RowsEventData::UpdateRowsEventV1(ev) => ev.flags(),
+            RowsEventData::DeleteRowsEventV1(ev) => ev.flags(),
+            RowsEventData::WriteRowsEvent(ev) => ev.flags(),
+            RowsEventData::UpdateRowsEvent(ev) => ev.flags(),
+            RowsEventData::DeleteRowsEvent(ev) => ev.flags(),
+            RowsEventData::PartialUpdateRowsEvent(ev) => ev.flags(),
         }
     }
 

--- a/src/binlog/events/partial_update_rows_event.rs
+++ b/src/binlog/events/partial_update_rows_event.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -56,6 +56,11 @@ impl<'a> PartialUpdateRowsEvent<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/rows_event.rs
+++ b/src/binlog/events/rows_event.rs
@@ -124,6 +124,11 @@ impl<'a> RowsEvent<'a> {
         self.rows_data.as_bytes()
     }
 
+    /// Returns the flags (unknown bits are truncated).
+    pub fn flags(&self) -> RowsEventFlags {
+        self.flags.get()
+    }
+
     /// Returns length of this event in bytes.
     ///
     /// This function will be used in `BinlogStruct` implementations for derived events.

--- a/src/binlog/events/update_rows_event.rs
+++ b/src/binlog/events/update_rows_event.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -57,6 +57,11 @@ impl<'a> UpdateRowsEvent<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/update_rows_event_v1.rs
+++ b/src/binlog/events/update_rows_event_v1.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -54,6 +54,11 @@ impl<'a> UpdateRowsEventV1<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/write_rows_event.rs
+++ b/src/binlog/events/write_rows_event.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -49,6 +49,11 @@ impl<'a> WriteRowsEvent<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.

--- a/src/binlog/events/write_rows_event_v1.rs
+++ b/src/binlog/events/write_rows_event_v1.rs
@@ -12,7 +12,7 @@ use std::io::{self};
 
 use crate::{
     binlog::{
-        consts::{BinlogVersion, EventType},
+        consts::{BinlogVersion, EventType, RowsEventFlags},
         BinlogCtx, BinlogEvent, BinlogStruct,
     },
     io::ParseBuf,
@@ -47,6 +47,11 @@ impl<'a> WriteRowsEventV1<'a> {
     /// Returns raw rows data.
     pub fn rows_data(&'a self) -> &'a [u8] {
         self.0.rows_data()
+    }
+
+    /// Returns row flags.
+    pub fn flags(&'a self) -> RowsEventFlags {
+        self.0.flags()
     }
 
     /// Returns an iterator over event's rows given the corresponding `TableMapEvent`.


### PR DESCRIPTION
In our use-case at Materialize we are looking to gain access to the underlying flags attached to `RowsEvent`s to determine whether they represent the final event for a given statement/transaction.

Thanks!