### PR TITLE
added: parse integers to bool

### DIFF
--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -233,8 +233,8 @@ impl TryFrom<Value> for ParseIrOpt<bool> {
 
     fn try_from(v: Value) -> Result<Self, Self::Error> {
         match v {
-            Value::Int(0) => Ok(ParseIrOpt::Ready(false)),
-            Value::Int(1) => Ok(ParseIrOpt::Ready(true)),
+            Value::Int(0) | Value::UInt(0) => Ok(ParseIrOpt::Ready(false)),
+            Value::Int(_) | Value::UInt(_) => Ok(ParseIrOpt::Ready(true)),
             Value::Bytes(ref bytes) => match bytes.as_slice() {
                 [b'0'] => Ok(ParseIrOpt::Parsed(false, v)),
                 [b'1'] => Ok(ParseIrOpt::Parsed(true, v)),
@@ -1010,6 +1010,26 @@ mod tests {
         fn parse_mysql_datetime_string_doesnt_crash(s in "\\PC*") {
             parse_mysql_datetime_string(s.as_bytes());
             let _ = super::time02::parse_mysql_datetime_string_with_time(s.as_bytes());
+        }
+
+        #[test]
+        fn parse_int_as_bool(n: i64) {
+            let val = Value::Int(n);
+            if n == 0 {
+                assert_eq!(from_value::<bool>(val), false);
+            } else {
+                assert_eq!(from_value::<bool>(val), true);
+            }
+        }
+
+        #[test]
+        fn parse_uint_as_bool(n: u64) {
+            let val = Value::UInt(n);
+            if n == 0 {
+                assert_eq!(from_value::<bool>(val), false);
+            } else {
+                assert_eq!(from_value::<bool>(val), true);
+            }
         }
 
         #[test]


### PR DESCRIPTION
fixes #133 

the mysql specification at https://github.com/blackbeam/rust_mysql_common/issues/url states that all TinyInt values between -128 and 127 are valid as the boolean value true (with the exclusion of 0 being false).

other clients have implemented the full range of their respective integer classes (e.g jdbc's Integer) conversions into boolean.

this commit adds that simple logic with either Value::Int(0) and Value::Uint(0) being false and all other Value::Int's and Value::UInt's being true.

proptests for both ranges were also added for sanity/regressions sake.