### PR TITLE
Added implementation of client_ed25519 authentification method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ serde_json = "1"
 mysql-common-derive = { path = "derive", version = "0.31.0", optional = true }
 btoi = "0.4.3"
 zstd = "0.13"
+curve25519-dalek = { version = "4.1.3" }
 
 [dev-dependencies]
 proptest = "1.0"

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     proto::{MyDeserialize, MySerialize},
     value::{ClientSide, SerializationSide, Value},
 };
-use crate::scramble::createResponseForEd25519;
+use crate::scramble::create_response_for_ed25519;
 
 use self::session_state_change::SessionStateChange;
 
@@ -1253,7 +1253,7 @@ impl<'a> AuthPlugin<'a> {
                     Some(AuthPluginData::Clear(Cow::Borrowed(pass.as_bytes())))
                 }
                 AuthPlugin::Ed25519 => {
-                    Some(createResponseForEd25519(pass.as_bytes(), nonce)).map(AuthPluginData::Ed25519)
+                    Some(AuthPluginData::Ed25519(create_response_for_ed25519(pass.as_bytes(), nonce)))
                 }
                 AuthPlugin::Other(_) => None,
             },

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use crate::collations::CollationId;
+use crate::scramble::create_response_for_ed25519;
 use crate::{
     constants::{
         CapabilityFlags, ColumnFlags, ColumnType, Command, CursorType, SessionStateType,
@@ -40,7 +41,6 @@ use crate::{
     proto::{MyDeserialize, MySerialize},
     value::{ClientSide, SerializationSide, Value},
 };
-use crate::scramble::create_response_for_ed25519;
 
 use self::session_state_change::SessionStateChange;
 
@@ -1252,9 +1252,10 @@ impl<'a> AuthPlugin<'a> {
                 AuthPlugin::MysqlClearPassword => {
                     Some(AuthPluginData::Clear(Cow::Borrowed(pass.as_bytes())))
                 }
-                AuthPlugin::Ed25519 => {
-                    Some(AuthPluginData::Ed25519(create_response_for_ed25519(pass.as_bytes(), nonce)))
-                }
+                AuthPlugin::Ed25519 => Some(AuthPluginData::Ed25519(create_response_for_ed25519(
+                    pass.as_bytes(),
+                    nonce,
+                ))),
                 AuthPlugin::Other(_) => None,
             },
             _ => None,

--- a/src/scramble.rs
+++ b/src/scramble.rs
@@ -161,6 +161,15 @@ pub fn scramble_sha256(nonce: &[u8], password: &[u8]) -> Option<[u8; 32]> {
     ))
 }
 
+/// Creating Response and Hash
+///
+pub fn createResponseForEd25519(pass: &[u8], challenge: &[u8]) -> [u8;64] {
+    // Following reference implementation at https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector.Authentication.Ed25519/Ed25519AuthenticationPlugin.cs#L35
+    // https://github.com/mariadb-corporation/mariadb-connector-j/blob/3657cd62e43968d1c99f6c531ee5766c4d706dc1/src/main/java/org/mariadb/jdbc/plugin/authentication/standard/Ed25519PasswordPlugin.java
+    // and https://github.com/MariaDB/server/blob/592fe954ef82be1bc08b29a8e54f7729eb1e1343/plugin/auth_ed25519/ref10/sign.c#L7
+    unimplemented!()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/scramble.rs
+++ b/src/scramble.rs
@@ -6,11 +6,11 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::convert::TryInto;
-use curve25519_dalek::{EdwardsPoint, Scalar};
 use curve25519_dalek::scalar::clamp_integer;
+use curve25519_dalek::{EdwardsPoint, Scalar};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
+use std::convert::TryInto;
 
 fn xor<T, U>(mut left: T, right: U) -> T
 where
@@ -165,19 +165,17 @@ pub fn scramble_sha256(nonce: &[u8], password: &[u8]) -> Option<[u8; 32]> {
 }
 
 /// Crafting a signature according to EdDSA for message using the pass
-pub fn create_response_for_ed25519(pass: &[u8], message: &[u8]) -> [u8;64] {
+pub fn create_response_for_ed25519(pass: &[u8], message: &[u8]) -> [u8; 64] {
     // Following reference implementation at https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector.Authentication.Ed25519/Ed25519AuthenticationPlugin.cs#L35
     // with additional guidance from https://www.rfc-editor.org/rfc/rfc8032#section-5.1.5
     // Relying on functions provided by curve25519_dalek
 
     // hash the provided password
-    let hashed_pass = Sha512::default()
-        .chain_update(pass)
-        .finalize();
+    let hashed_pass = Sha512::default().chain_update(pass).finalize();
 
     // the hashed password is split into secret and hash_prefix
-    let secret: &[u8;32] = &hashed_pass[..32].try_into().unwrap();
-    let hash_prefix: &[u8;32] = &hashed_pass[32..].try_into().unwrap();
+    let secret: &[u8; 32] = &hashed_pass[..32].try_into().unwrap();
+    let hash_prefix: &[u8; 32] = &hashed_pass[32..].try_into().unwrap();
 
     // The public key A is the encoding of the point [s]B, where s is the clamped secret
     let small_s = clamp_integer(*secret);
@@ -217,7 +215,7 @@ pub fn create_response_for_ed25519(pass: &[u8], message: &[u8]) -> [u8;64] {
     // little-endian encoding of S (32 octets; the three most
     // significant bits of the final octet are always zero).
 
-    let mut result = [0;64];
+    let mut result = [0; 64];
     result[..32].copy_from_slice(capital_r.as_bytes());
     result[32..].copy_from_slice(capital_s.as_bytes());
 


### PR DESCRIPTION
I have tried my best at implementing a fix for issue #138 by following the given reference implementation as well as the RFC at https://www.rfc-editor.org/rfc/rfc8032#section-5.1.5. 

I have aligned my code as best as I can to the references given above and I have tested this locally using a modified `mysql_async`. However **I am no expert on cryptography** and cannot in good conscience take responsibility for the cryptographic correctness, as I am relying on low-level elliptic curve computations. 

If anyone could provide feedback and test data, I would very much appreciate it.

If this is accepted, I have already prepared the necessary changes to https://github.com/blackbeam/mysql_async/ as well. Should I open a separate pull request already, or wait?

Best regards!
