### PR TITLE
Replace proc-macro-error crate with proc-macro-error2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -22,7 +22,7 @@ darling = "0.20.1"
 heck = "0.4.0"
 num-bigint = "0.4.3"
 proc-macro-crate = "3"
-proc-macro-error = "1"
+proc-macro-error2 = "2.0.1"
 proc-macro2 = "1.0.42"
 quote = "1.0.9"
 syn = { version = "2.0", features = ["full"] }

--- a/derive/src/error.rs
+++ b/derive/src/error.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Span;
-use proc_macro_error::{Diagnostic, Level};
+use proc_macro_error2::{Diagnostic, Level};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/derive/src/from_row/structs/mod.rs
+++ b/derive/src/from_row/structs/mod.rs
@@ -1,6 +1,6 @@
 use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{ToTokens, TokenStreamExt};
 use syn::ext::IdentExt;
 use syn::spanned::Spanned;

--- a/derive/src/from_value/enums/mod.rs
+++ b/derive/src/from_value/enums/mod.rs
@@ -7,7 +7,7 @@ use attrs::{
 use darling::{FromAttributes, FromMeta};
 use num_bigint::BigInt;
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{ToTokens, TokenStreamExt};
 use syn::spanned::Spanned;
 

--- a/derive/src/from_value/structs/mod.rs
+++ b/derive/src/from_value/structs/mod.rs
@@ -1,7 +1,7 @@
 use darling::FromMeta;
 use heck::AsSnakeCase;
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{ToTokens, TokenStreamExt};
 
 use super::enums::attrs::container::Crate;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate proc_macro;
 
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 
 use crate::error::Error;
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -15,7 +15,7 @@ mod from_value;
 
 /// Derives `FromValue`. See `mysql_common` crate-level docs for more info.
 #[proc_macro_derive(FromValue, attributes(mysql))]
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: syn::DeriveInput = syn::parse(input).unwrap();
     match from_value::impl_from_value(&input) {
@@ -26,7 +26,7 @@ pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Derives `FromRow`. See `mysql_common` crate-level docs for more info.
 #[proc_macro_derive(FromRow, attributes(mysql))]
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 pub fn from_row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: syn::DeriveInput = syn::parse(input).unwrap();
     match from_row::impl_from_row(&input) {


### PR DESCRIPTION
Running cargo-deny reveals that the former is unmaintained (no releases for four years).  The latter is a drop-in replacement.