### PR TITLE
replace rand with getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ chrono = { version = "0.4.20", default-features = false, features = [
 crc32fast = "1.2"
 flate2 = { version = "1.0", default-features = false }
 frunk = { version = "0.4", optional = true }
+getrandom = "0.3"
 num-bigint = { version = "0.4" }
 num-traits = { version = "0.2", features = ["i128"] }
-rand = "0.8"
 regex = "1.5"
 rust_decimal = { version = "1.0", optional = true }
 sha1 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono = { version = "0.4.20", default-features = false, features = [
 crc32fast = "1.2"
 flate2 = { version = "1.0", default-features = false }
 frunk = { version = "0.4", optional = true }
-getrandom = "0.3"
+getrandom = { version = "0.3", features = ["std"] }
 num-bigint = { version = "0.4" }
 num-traits = { version = "0.2", features = ["i128"] }
 regex = "1.5"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -14,6 +14,6 @@ pub mod rsa;
 /// It will use OAEP padding, so MySql versions prior to 8.0.5 are not supported.
 pub fn encrypt(pass: &[u8], key: &[u8]) -> Vec<u8> {
     let pub_key = self::rsa::PublicKey::from_pem(key);
-    let pad = self::rsa::Pkcs1OaepPadding::new(self::rsa::OsRng);
+    let pad = self::rsa::Pkcs1OaepPadding::new(self::rsa::GetRandom);
     pub_key.encrypt_block(pass, pad)
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,8 +6,6 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use rand::rngs::OsRng;
-
 pub mod der;
 pub mod rsa;
 
@@ -16,6 +14,6 @@ pub mod rsa;
 /// It will use OAEP padding, so MySql versions prior to 8.0.5 are not supported.
 pub fn encrypt(pass: &[u8], key: &[u8]) -> Vec<u8> {
     let pub_key = self::rsa::PublicKey::from_pem(key);
-    let pad = self::rsa::Pkcs1OaepPadding::new(OsRng);
+    let pad = self::rsa::Pkcs1OaepPadding::new(self::rsa::OsRng);
     pub_key.encrypt_block(pass, pad)
 }


### PR DESCRIPTION
rand 0.9 split out fallible operations from Rng to TryRng

OsRng in rand 0.9 only implements the fallible trait

rand is not meant to be used for crypto, which is the case here

I've made an initial take where we replace Rng with our own trait that wraps getrandom. This allows test to continue using deterministic test case

Maybe these methods should return the error from `fill` rather than panic. But figured I'd keep this change conservative