### PR TITLE
build(deps): gate `cc`, `cmake` and `subprocess` behind `test` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ unic-langid = { version = "0.9.4" }
 bindgen = { version = "0.70", default-features = false, features = [
     "runtime",
 ], optional = true }
-cc = "1.0"
-cmake = "0.1"
-subprocess = "0.2"
+cc = { version = "1.0", optional = true }
+cmake = { version = "0.1", optional = true }
+subprocess = { version = "0.2", optional = true }
 
 [profile.bench]
 debug = true
@@ -88,7 +88,7 @@ incremental = false
 
 [features]
 default = ["flate2/zlib", "derive"]
-test = ["derive", "time", "bindgen"]
+test = ["derive", "time", "bindgen", "dep:cc", "dep:cmake", "dep:subprocess"]
 derive = ["mysql-common-derive"]
 binlog = ["bitvec"]
 nightly = ["test"]


### PR DESCRIPTION
Same as #165 but for dependencies required for `build_test_libs.rs`