### PR TITLE
Issue#401 Adding required definitions for MariaDB metadata skipping

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -362,11 +362,11 @@ my_bitflags! {
 
 my_bitflags! {
     MariadbCapabilities,
-    #[error("Unknown flags in the raw value of CapabilityFlags (raw={0:b})")]
+    #[error("Unknown flags in the raw value of MariadbCapabilities (raw={0:b})")]
     UnknownMariadbCapabilityFlags,
     u32,
 
-    /// Client capability flags
+    /// Mariadb client capability flags
     #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct MariadbCapabilities: u32 {
         /// Permits feedback during long-running operations


### PR DESCRIPTION
This is the part of the implementation of the [Issue#401](https://github.com/blackbeam/rust-mysql-simple/issues/401)
The solution requires changes to both mysql_common and to mysql-simple/async. This is the part for the common, obviously.
The change is independent and does not require changes in simple/async. Both can be built with it and tests pass without changes.

The patch is defining MariadbCapabilities completely in analogy with standard client capability flags. MariadbCapabilities contains all existing to the moment MariaDB specific/extended capabilities.

Also adding new constructor for HandshakeResponse class to assemble the packet with MariaDB extended capabilities.

I'd probably like to hear comments to this one before submitting the counterpart for simple.

The PR is submitted on behalf of my employer, MariaDB Corporation plc. We are planning further support and implement MariaDB specific features.
