### PR TITLE
Shrink compression codec buffers to prevent memory bloat

### DIFF
--- a/src/proto/codec/mod.rs
+++ b/src/proto/codec/mod.rs
@@ -626,9 +626,7 @@ impl CompPacketCodec {
         {
             // After decoding, in_buf may be empty but still hold capacity
             // from previous large responses. Reclaim if over threshold.
-            if self.in_buf.is_empty()
-                && self.in_buf.capacity() > COMP_CODEC_SHRINK_THRESHOLD
-            {
+            if self.in_buf.is_empty() && self.in_buf.capacity() > COMP_CODEC_SHRINK_THRESHOLD {
                 self.in_buf = BytesMut::new();
             }
             return Ok(true);

--- a/src/proto/codec/mod.rs
+++ b/src/proto/codec/mod.rs
@@ -563,6 +563,12 @@ impl PlainPacketCodec {
     }
 }
 
+/// Compression codec buffers (`in_buf`, `out_buf`) grow to accommodate large packets
+/// but never shrink back, effectively leaking memory for the lifetime of the connection.
+/// With 20+ compressed connections this can waste 200-500 MB of RSS.
+/// We reclaim buffers that have grown past this threshold once they are fully drained.
+const COMP_CODEC_SHRINK_THRESHOLD: usize = 4 * 1024 * 1024;
+
 /// Codec for compressed MySql protocol.
 #[derive(Debug)]
 struct CompPacketCodec {
@@ -618,6 +624,13 @@ impl CompPacketCodec {
                 Some(self.comp_seq_id.wrapping_sub(1)),
             )?
         {
+            // After decoding, in_buf may be empty but still hold capacity
+            // from previous large responses. Reclaim if over threshold.
+            if self.in_buf.is_empty()
+                && self.in_buf.capacity() > COMP_CODEC_SHRINK_THRESHOLD
+            {
+                self.in_buf = BytesMut::new();
+            }
             return Ok(true);
         }
 
@@ -655,6 +668,12 @@ impl CompPacketCodec {
             &mut self.out_buf,
             dst,
         )?;
+
+        // compress() drains out_buf but leaves allocated capacity behind.
+        // Reclaim if over threshold to avoid holding megabytes idle.
+        if self.out_buf.capacity() > COMP_CODEC_SHRINK_THRESHOLD {
+            self.out_buf = BytesMut::new();
+        }
 
         /* Sync packet number if using compression (see net_serv.cc) */
         self.plain_codec.seq_id = self.comp_seq_id;


### PR DESCRIPTION
## Problem

`CompPacketCodec`'s `in_buf` and `out_buf` (`BytesMut`) grow to accommodate large compressed/decompressed packets but **never shrink back**. Over time every compressed connection accumulates megabytes of idle capacity in these buffers. With 20+ compressed connections this easily wastes 200–500 MB of RSS.

Relates to blackbeam/mysql_async#349.

## Fix

After each decode/encode cycle, if a buffer is fully drained (`is_empty()`) and its allocated capacity exceeds a 4 MiB threshold, replace it with a fresh `BytesMut::new()`.

This is:
- **Zero-cost for normal traffic** — the check only fires when buffers are already empty
- **Conservative** — 4 MiB threshold avoids churn for reasonably-sized buffers
- **Minimal** — 19 lines added, no API changes, no new dependencies

## Production status

We've been running an equivalent patch (with a 1 MiB threshold) in production for several months against MySQL 5.1.53 with compression enabled, ~20 concurrent connections. Memory usage dropped from ~400 MB to ~40 MB with no issues.

## Open to feedback

If you'd prefer this threshold to be configurable (e.g. via a field on `CompPacketCodec` or a connection option), happy to rework. The hardcoded constant felt like the least invasive starting point.