### PR TITLE
Support sha256_password auth plugin

### DIFF
--- a/CRATE_LEVEL_DOCS.md
+++ b/CRATE_LEVEL_DOCS.md
@@ -55,7 +55,25 @@ Also crate provides from-row conversion for the following list of types (see `Fr
 | `Row`                                           | Trivial conversion for `Row` itself.              |
 | `T: FromValue`                                  | For rows with a single column.                    |
 | `(T1: FromValue [, ..., T12: FromValue])`       | Row to a tuple of arity 1-12.                     |
-| [`frunk::hlist::HList`] types                   | Useful to overcome tuple arity limitation        |
+| [`frunk::hlist::HList`] types                   | Useful to overcome tuple arity limitation         |
+
+## Supproted auth plugins
+
+Auth plugins are implemented as state machines and exposed as [`AuthProc`] dispatcher
+implementing the [`ChallengeResponsePlugin`] trait.
+
+[`AuthProc`]: crate::auth::plugins::AuthProc
+[`ChallengeResponsePlugin`]: crate::auth::plugins::ChallengeResponsePlugin
+
+| Name                  | Notes                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| CachingSha2Password   | Default MySql plugin since v8                                                        |
+| Parsec                | The most recent MariaDb plugin (behind `client_parsec` feature)                      |
+| MysqlNativePassword   | Classic MySql/MariaDb authentication plugin                                          |
+| Sha256Password        | An improvement over MysqlNativePassword introduced in v5.6 and deprecated in v8.0.16 |
+| ClientEd25519         | Relatively new but controversial MariaDb plugin (behind `client_ed25519` feature)    |
+| MysqlOldPassword      | Old md5-based MySql authentication plugin replaced by MysqlNativePassword            |
+| MysqlClearPassword    | Client-side plugin that sends the password in clear text                             |
 
 ## Crate features
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,25 @@ Also crate provides from-row conversion for the following list of types (see `Fr
 | `Row`                                           | Trivial conversion for `Row` itself.              |
 | `T: FromValue`                                  | For rows with a single column.                    |
 | `(T1: FromValue [, ..., T12: FromValue])`       | Row to a tuple of arity 1-12.                     |
-| [`frunk::hlist::HList`] types                   | Useful to overcome tuple arity limitation        |
+| [`frunk::hlist::HList`] types                   | Useful to overcome tuple arity limitation         |
+
+### Supproted auth plugins
+
+Auth plugins are implemented as state machines and exposed as [`AuthProc`] dispatcher
+implementing the [`ChallengeResponsePlugin`] trait.
+
+[`AuthProc`]: crate::auth::plugins::AuthProc
+[`ChallengeResponsePlugin`]: crate::auth::plugins::ChallengeResponsePlugin
+
+| Name                  | Notes                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| CachingSha2Password   | Default MySql plugin since v8                                                        |
+| Parsec                | The most recent MariaDb plugin (behind `client_parsec` feature)                      |
+| MysqlNativePassword   | Classic MySql/MariaDb authentication plugin                                          |
+| Sha256Password        | An improvement over MysqlNativePassword introduced in v5.6 and deprecated in v8.0.16 |
+| ClientEd25519         | Relatively new but controversial MariaDb plugin (behind `client_ed25519` feature)    |
+| MysqlOldPassword      | Old md5-based MySql authentication plugin replaced by MysqlNativePassword            |
+| MysqlClearPassword    | Client-side plugin that sends the password in clear text                             |
 
 ### Crate features
 

--- a/src/auth/plugins/caching_sha2_password.rs
+++ b/src/auth/plugins/caching_sha2_password.rs
@@ -8,13 +8,12 @@ use crate::{
     crypto,
 };
 
+const REQUEST_SERVER_KEY: u8 = 0x02;
 const FAST_AUTH_SUCCESS: u8 = 0x03;
 const PERFORM_FULL_AUTHENTICATION: u8 = 0x04;
 
 #[derive(Debug, Default)]
 pub struct CachingSha2Password(State);
-
-impl CachingSha2Password {}
 
 #[derive(Debug, Default, Clone, Copy)]
 enum State {
@@ -51,9 +50,7 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
 
                 if ctx.pass().is_empty() {
                     self.0 = State::Done;
-                    return Ok(super::Response::Last {
-                        packet: Some(Vec::new()),
-                    });
+                    return Ok(super::Response::last_empty());
                 }
 
                 let response = scramble_sha256(scramble, ctx.pass())
@@ -74,16 +71,16 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
                     FAST_AUTH_SUCCESS => {
                         // cached
                         self.0 = State::Done;
-                        Ok(super::Response::Last { packet: None })
+                        Ok(super::Response::last_none())
                     }
                     PERFORM_FULL_AUTHENTICATION => {
                         // not cached
-                        if ctx.is_secure_transport() {
-                            // just send the password in case of a secure transport
+                        if ctx.is_tls_transport() || ctx.is_ipc_transport() {
+                            // just send the null-terminated password in case of a secure transport
                             self.0 = State::Done;
                             let mut pass = ctx.pass().to_vec();
                             pass.push(0x00);
-                            Ok(super::Response::Last { packet: Some(pass) })
+                            Ok(super::Response::last(pass))
                         } else {
                             if let Some(key) = ctx.server_key_pem() {
                                 let response = encrypt_pass(ctx.pass(), ctx.scramble(), key)?;
@@ -92,9 +89,7 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
                             } else {
                                 // requesting server's public key
                                 self.0 = State::Step3;
-                                Ok(super::Response::Next {
-                                    packet: Some(vec![0x02]),
-                                })
+                                Ok(super::Response::next(vec![REQUEST_SERVER_KEY]))
                             }
                         }
                     }
@@ -106,9 +101,7 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
                 self.0 = State::Done;
                 Ok(response)
             }
-            State::Done => {
-                panic!("ChallengeResponsePlugin::run called after Response::Last returned")
-            }
+            State::Done => Err(super::Error::Logic),
         }
     }
 

--- a/src/auth/plugins/caching_sha2_password.rs
+++ b/src/auth/plugins/caching_sha2_password.rs
@@ -8,6 +8,9 @@ use crate::{
     crypto,
 };
 
+const FAST_AUTH_SUCCESS: u8 = 0x03;
+const PERFORM_FULL_AUTHENTICATION: u8 = 0x04;
+
 #[derive(Debug, Default)]
 pub struct CachingSha2Password(State);
 
@@ -63,23 +66,17 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
                 })
             }
             State::Step2 => {
-                let value = if let Ok([0x01, value]) = <&[u8; 2]>::try_from(challenge) {
-                    // escaping 0x01 byte was not removed by the caller
-                    value
-                } else if let Ok([value]) = <&[u8; 1]>::try_from(challenge) {
-                    // escaping 0x01 byte was removed by the caller
-                    value
-                } else {
+                let Ok([cache_state]) = <[u8; 1]>::try_from(challenge) else {
                     return Err(super::Error::Challenge);
                 };
 
-                match value {
-                    0x03 => {
+                match cache_state {
+                    FAST_AUTH_SUCCESS => {
                         // cached
                         self.0 = State::Done;
                         Ok(super::Response::Last { packet: None })
                     }
-                    0x04 => {
+                    PERFORM_FULL_AUTHENTICATION => {
                         // not cached
                         if ctx.is_secure_transport() {
                             // just send the password in case of a secure transport
@@ -105,15 +102,7 @@ impl super::ChallengeResponsePlugin for CachingSha2Password {
                 }
             }
             State::Step3 => {
-                let key = if challenge.starts_with(b"\x01") {
-                    // RSA public key starts with a dash, so the escaping 0x01 byte
-                    // was not removed by the caller
-                    &challenge[1..]
-                } else {
-                    challenge
-                };
-
-                let response = encrypt_pass(ctx.pass(), ctx.scramble(), key)?;
+                let response = encrypt_pass(ctx.pass(), ctx.scramble(), challenge)?;
                 self.0 = State::Done;
                 Ok(response)
             }

--- a/src/auth/plugins/client_ed25519.rs
+++ b/src/auth/plugins/client_ed25519.rs
@@ -73,9 +73,7 @@ impl super::ChallengeResponsePlugin for ClientEd25519 {
         result[..32].copy_from_slice(capital_r.as_bytes());
         result[32..].copy_from_slice(capital_s.as_bytes());
 
-        Ok(super::Response::Last {
-            packet: Some(result.to_vec()),
-        })
+        Ok(super::Response::last(result.to_vec()))
     }
 
     fn password_hash<C: super::Context>(&self, ctx: C) -> Option<Vec<u8>> {

--- a/src/auth/plugins/mod.rs
+++ b/src/auth/plugins/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     auth::plugins::{
         caching_sha2_password::CachingSha2Password, client_ed25519::ClientEd25519,
         mysql_clear_password::MysqlClearPassword, mysql_native_password::MysqlNativePassword,
-        mysql_old_password::MysqlOldPassword, parsec::Parsec,
+        mysql_old_password::MysqlOldPassword, parsec::Parsec, sha256_password::Sha256Password,
     },
     packets::AuthPlugin,
 };
@@ -13,6 +13,7 @@ pub mod mysql_clear_password;
 pub mod mysql_native_password;
 pub mod mysql_old_password;
 pub mod parsec;
+pub mod sha256_password;
 
 /// Initialized authentication procedure.
 ///
@@ -25,6 +26,7 @@ pub enum AuthProc {
     MysqlClearPassword(MysqlClearPassword),
     MysqlNativePassword(MysqlNativePassword),
     MysqlOldPassword(MysqlOldPassword),
+    Sha256Password(Sha256Password),
     #[cfg_attr(docsrs, doc(cfg(feature = "client_parsec")))]
     Parsec(Parsec),
 }
@@ -44,6 +46,7 @@ impl AuthProc {
             AuthPlugin::CachingSha2Password => Ok(Self::CachingSha2Password(Default::default())),
             AuthPlugin::Ed25519 => Ok(Self::ClientEd25519(Default::default())),
             AuthPlugin::Parsec => Ok(Self::Parsec(Default::default())),
+            AuthPlugin::Sha256Password => Ok(Self::Sha256Password(Default::default())),
             AuthPlugin::Other(name) => {
                 Err(PluginInitError::UnsupportedPlugin(name.as_ref().to_owned()))
             }
@@ -59,6 +62,7 @@ impl ChallengeResponsePlugin for AuthProc {
             AuthProc::MysqlClearPassword(x) => x.run(ctx, challenge),
             AuthProc::MysqlNativePassword(x) => x.run(ctx, challenge),
             AuthProc::MysqlOldPassword(x) => x.run(ctx, challenge),
+            AuthProc::Sha256Password(x) => x.run(ctx, challenge),
             AuthProc::Parsec(x) => x.run(ctx, challenge),
         }
     }
@@ -70,6 +74,7 @@ impl ChallengeResponsePlugin for AuthProc {
             AuthProc::MysqlClearPassword(x) => x.password_hash(ctx),
             AuthProc::MysqlNativePassword(x) => x.password_hash(ctx),
             AuthProc::MysqlOldPassword(x) => x.password_hash(ctx),
+            AuthProc::Sha256Password(x) => x.password_hash(ctx),
             AuthProc::Parsec(x) => x.password_hash(ctx),
         }
     }
@@ -77,6 +82,10 @@ impl ChallengeResponsePlugin for AuthProc {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("The order of challenges/responses given does not match the plugin logic")]
+    Logic,
+    #[error("Password does not match plugin requirements")]
+    Password,
     #[error("Bad auth plugin challenge")]
     Challenge,
     #[error("`{_0}` feature must be enabled for this plugin to work")]
@@ -98,8 +107,10 @@ impl PartialEq for Error {
 pub trait Context {
     /// User password
     fn pass(&self) -> &[u8];
-    /// Whether the transport is TLS/IPC.
-    fn is_secure_transport(&self) -> bool;
+    /// Whether the transport is IPC.
+    fn is_ipc_transport(&self) -> bool;
+    /// Whether the transport is TLS
+    fn is_tls_transport(&self) -> bool;
     /// Initial handshake scramble.
     fn scramble(&self) -> &[u8];
     /// The public key server uses for RSA-based key exchange
@@ -121,14 +132,37 @@ pub enum Response {
 }
 
 impl Response {
-    /// Convenience function returning an empty packet response asking for anothe challenge.
+    /// Convenience function returning empty packet response asking for anothe challenge.
     pub fn next_empty() -> Self {
         Self::Next {
             packet: Some(Vec::new()),
         }
     }
 
-    pub fn packet(&self) -> Option<&[u8]> {
+    /// Convenience function asking for another challenge.
+    pub fn next(data: Vec<u8>) -> Self {
+        Self::Next { packet: Some(data) }
+    }
+
+    /// Convenience function returning the last empty packet response.
+    pub fn last_empty() -> Self {
+        Self::Last {
+            packet: Some(Vec::new()),
+        }
+    }
+
+    /// Convenience function returning the last response.
+    pub fn last(data: Vec<u8>) -> Self {
+        Self::Last { packet: Some(data) }
+    }
+
+    /// Convenience function returning no response.
+    pub fn last_none() -> Self {
+        Self::Last { packet: None }
+    }
+
+    /// Returns the data to send to the server (if any).
+    pub fn data(&self) -> Option<&[u8]> {
         match self {
             Response::Next { packet } | Response::Last { packet } => packet.as_deref(),
         }

--- a/src/auth/plugins/mod.rs
+++ b/src/auth/plugins/mod.rs
@@ -137,6 +137,12 @@ impl Response {
 
 pub trait ChallengeResponsePlugin {
     /// Runs a single step of a challenge-response authentication.
+    ///
+    /// Note that the caller must properly preprocess the challenge, namely:
+    ///
+    /// * abort on error packet
+    /// * handle auth switch request
+    /// * remove leading 0x01 byte added by the server to escape the binary data
     fn run<C: Context>(&mut self, ctx: C, challenge: &[u8]) -> Result<Response, Error>;
 
     /// Returns a password hash for MariaDb "zero-config TLS" feature.

--- a/src/auth/plugins/mysql_clear_password.rs
+++ b/src/auth/plugins/mysql_clear_password.rs
@@ -10,9 +10,7 @@ impl super::ChallengeResponsePlugin for MysqlClearPassword {
         let pass = ctx.pass();
         let mut cleartext_pass = vec![0_u8; pass.len() + 1];
         cleartext_pass[..pass.len()].copy_from_slice(pass);
-        Ok(super::Response::Last {
-            packet: Some(cleartext_pass),
-        })
+        Ok(super::Response::last(cleartext_pass))
     }
 
     fn password_hash<C: super::Context>(&self, _ctx: C) -> Option<Vec<u8>> {

--- a/src/auth/plugins/mysql_native_password.rs
+++ b/src/auth/plugins/mysql_native_password.rs
@@ -23,9 +23,7 @@ impl super::ChallengeResponsePlugin for MysqlNativePassword {
             .map(|x| x.to_vec())
             .unwrap_or_default();
 
-        Ok(super::Response::Last {
-            packet: Some(response),
-        })
+        Ok(super::Response::last(response))
     }
 
     fn password_hash<C: super::Context>(&self, ctx: C) -> Option<Vec<u8>> {

--- a/src/auth/plugins/mysql_old_password.rs
+++ b/src/auth/plugins/mysql_old_password.rs
@@ -21,9 +21,7 @@ impl super::ChallengeResponsePlugin for MysqlOldPassword {
             .map(|x| x.to_vec())
             .unwrap_or_default();
 
-        Ok(super::Response::Last {
-            packet: Some(response),
-        })
+        Ok(super::Response::last(response))
     }
 
     fn password_hash<C: super::Context>(&self, _ctx: C) -> Option<Vec<u8>> {

--- a/src/auth/plugins/parsec.rs
+++ b/src/auth/plugins/parsec.rs
@@ -117,13 +117,9 @@ impl super::ChallengeResponsePlugin for Parsec {
 
                 self.0 = State::Done { password_hash };
 
-                Ok(super::Response::Last {
-                    packet: Some(message_and_signature[32..].to_vec()),
-                })
+                Ok(super::Response::last(message_and_signature[32..].to_vec()))
             }
-            State::Done { .. } => {
-                panic!("ChallengeResponsePlugin::run called after Response::Last returned")
-            }
+            State::Done { .. } => Err(super::Error::Logic),
         }
     }
 

--- a/src/auth/plugins/sha256_password.rs
+++ b/src/auth/plugins/sha256_password.rs
@@ -1,0 +1,93 @@
+use crate::crypto;
+
+const REQUEST_SERVER_KEY: u8 = 0x01;
+const SCRAMBLE_LENGTH: usize = 20;
+
+#[derive(Debug, Default)]
+pub struct Sha256Password(State);
+
+#[derive(Debug, Default, Clone, Copy)]
+enum State {
+    #[default]
+    /// Expects server nonce
+    ///
+    /// * goes to `Done` on empty password, TLS transport or known server key
+    /// * goes to `Step2` otherwise
+    Init,
+    /// Expects server key
+    ///
+    /// * goes to `Done`
+    Step2 {
+        /// sha256_password preferes plugin scramble over handshake scramble
+        plugin_scramble: [u8; SCRAMBLE_LENGTH],
+    },
+    Done,
+}
+
+impl super::ChallengeResponsePlugin for Sha256Password {
+    fn run<C: super::Context>(
+        &mut self,
+        ctx: C,
+        challenge: &[u8],
+    ) -> Result<super::Response, super::Error> {
+        match self.0 {
+            State::Init => {
+                let Ok(plugin_scramble) = <&[u8; SCRAMBLE_LENGTH]>::try_from(challenge) else {
+                    return Err(super::Error::Challenge);
+                };
+
+                if ctx.pass().is_empty() {
+                    self.0 = State::Done;
+                    return Ok(super::Response::last_empty());
+                }
+
+                if ctx.is_tls_transport() {
+                    // just send the null-terminated password in case of a secure transport
+                    self.0 = State::Done;
+                    let mut pass = ctx.pass().to_vec();
+                    pass.push(0x00);
+                    return Ok(super::Response::last(pass));
+                }
+
+                if let Some(key) = ctx.server_key_pem() {
+                    let response = encrypt_pass(ctx.pass(), plugin_scramble, key)?;
+                    self.0 = State::Done;
+                    Ok(response)
+                } else {
+                    // requesting server's public key
+                    self.0 = State::Step2 {
+                        plugin_scramble: *plugin_scramble,
+                    };
+                    Ok(super::Response::next(vec![REQUEST_SERVER_KEY]))
+                }
+            }
+            State::Step2 {
+                plugin_scramble: server_nonce,
+            } => {
+                let response = encrypt_pass(ctx.pass(), &server_nonce, challenge)?;
+                self.0 = State::Done;
+                Ok(response)
+            }
+            State::Done => Err(super::Error::Logic),
+        }
+    }
+
+    fn password_hash<C: super::Context>(&self, _ctx: C) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+fn encrypt_pass(pass: &[u8], scramble: &[u8], key: &[u8]) -> Result<super::Response, super::Error> {
+    let mut pass = pass.to_vec();
+    pass.push(0x00);
+
+    for (i, c) in pass.iter_mut().enumerate() {
+        *(c) ^= scramble[i % scramble.len()];
+    }
+
+    match crypto::encrypt(&pass, key) {
+        Ok(encrypted_pass) => Ok(super::Response::last(encrypted_pass)),
+        Err(crypto::Error::Key(_)) => Err(super::Error::Challenge),
+        Err(crypto::Error::Padding(e)) => Err(super::Error::Other(Box::new(e))),
+    }
+}

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1183,6 +1183,7 @@ impl MySerialize for LocalInfilePacket<'_> {
 
 const MYSQL_OLD_PASSWORD_PLUGIN_NAME: &[u8] = b"mysql_old_password";
 const MYSQL_NATIVE_PASSWORD_PLUGIN_NAME: &[u8] = b"mysql_native_password";
+const SHA256_PASSWORD_PLUGIN_NAME: &[u8] = b"sha256_password";
 const CACHING_SHA2_PASSWORD_PLUGIN_NAME: &[u8] = b"caching_sha2_password";
 const MYSQL_CLEAR_PASSWORD_PLUGIN_NAME: &[u8] = b"mysql_clear_password";
 const ED25519_PLUGIN_NAME: &[u8] = b"client_ed25519";
@@ -1197,6 +1198,8 @@ pub enum AuthPlugin<'a> {
     MysqlClearPassword,
     /// Legacy authentication plugin
     MysqlNativePassword,
+    /// Deprecated SHA-256 authentication plugin.
+    Sha256Password,
     /// Default since MySql v8.0.4
     CachingSha2Password,
     /// MariaDB's Ed25519 based authentication
@@ -1235,6 +1238,7 @@ impl<'a> AuthPlugin<'a> {
             name
         };
         match name {
+            SHA256_PASSWORD_PLUGIN_NAME => AuthPlugin::Sha256Password,
             CACHING_SHA2_PASSWORD_PLUGIN_NAME => AuthPlugin::CachingSha2Password,
             MYSQL_NATIVE_PASSWORD_PLUGIN_NAME => AuthPlugin::MysqlNativePassword,
             MYSQL_OLD_PASSWORD_PLUGIN_NAME => AuthPlugin::MysqlOldPassword,
@@ -1247,6 +1251,7 @@ impl<'a> AuthPlugin<'a> {
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
+            AuthPlugin::Sha256Password => SHA256_PASSWORD_PLUGIN_NAME,
             AuthPlugin::CachingSha2Password => CACHING_SHA2_PASSWORD_PLUGIN_NAME,
             AuthPlugin::MysqlNativePassword => MYSQL_NATIVE_PASSWORD_PLUGIN_NAME,
             AuthPlugin::MysqlOldPassword => MYSQL_OLD_PASSWORD_PLUGIN_NAME,
@@ -1259,6 +1264,7 @@ impl<'a> AuthPlugin<'a> {
 
     pub fn into_owned(self) -> AuthPlugin<'static> {
         match self {
+            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::CachingSha2Password => AuthPlugin::CachingSha2Password,
             AuthPlugin::MysqlNativePassword => AuthPlugin::MysqlNativePassword,
             AuthPlugin::MysqlOldPassword => AuthPlugin::MysqlOldPassword,
@@ -1271,6 +1277,7 @@ impl<'a> AuthPlugin<'a> {
 
     pub fn borrow(&self) -> AuthPlugin<'_> {
         match self {
+            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::CachingSha2Password => AuthPlugin::CachingSha2Password,
             AuthPlugin::MysqlNativePassword => AuthPlugin::MysqlNativePassword,
             AuthPlugin::MysqlOldPassword => AuthPlugin::MysqlOldPassword,
@@ -4785,6 +4792,16 @@ mod test {
         let packet = AuthSwitchRequest::deserialize((), &mut ParseBuf(PAYLOAD)).unwrap();
         assert_eq!(packet.auth_plugin().as_bytes(), b"mysql_native_password",);
         assert_eq!(packet.plugin_data(), b"zQg4i6oNy6=rHN/>-b)A",)
+    }
+
+    #[test]
+    fn should_recognize_sha256_password_auth_plugin() {
+        let plugin = AuthPlugin::from_bytes(b"sha256_password");
+
+        assert_eq!(plugin, AuthPlugin::Sha256Password);
+        assert_eq!(plugin.as_bytes(), b"sha256_password");
+        assert_eq!(plugin.borrow(), AuthPlugin::Sha256Password);
+        assert_eq!(plugin.into_owned(), AuthPlugin::Sha256Password);
     }
 
     #[test]

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1198,7 +1198,7 @@ pub enum AuthPlugin<'a> {
     MysqlClearPassword,
     /// Legacy authentication plugin
     MysqlNativePassword,
-    /// Deprecated SHA-256 authentication plugin.
+    /// `sha256_password` plugin introduced in MySql 5.6 and deprecated in MySql 8.0.16
     Sha256Password,
     /// Default since MySql v8.0.4
     CachingSha2Password,
@@ -1238,52 +1238,52 @@ impl<'a> AuthPlugin<'a> {
             name
         };
         match name {
-            SHA256_PASSWORD_PLUGIN_NAME => AuthPlugin::Sha256Password,
             CACHING_SHA2_PASSWORD_PLUGIN_NAME => AuthPlugin::CachingSha2Password,
             MYSQL_NATIVE_PASSWORD_PLUGIN_NAME => AuthPlugin::MysqlNativePassword,
             MYSQL_OLD_PASSWORD_PLUGIN_NAME => AuthPlugin::MysqlOldPassword,
             MYSQL_CLEAR_PASSWORD_PLUGIN_NAME => AuthPlugin::MysqlClearPassword,
             ED25519_PLUGIN_NAME => AuthPlugin::Ed25519,
             PARSEC_PLUGIN_NAME => AuthPlugin::Parsec,
+            SHA256_PASSWORD_PLUGIN_NAME => AuthPlugin::Sha256Password,
             name => AuthPlugin::Other(Cow::Borrowed(name)),
         }
     }
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            AuthPlugin::Sha256Password => SHA256_PASSWORD_PLUGIN_NAME,
             AuthPlugin::CachingSha2Password => CACHING_SHA2_PASSWORD_PLUGIN_NAME,
             AuthPlugin::MysqlNativePassword => MYSQL_NATIVE_PASSWORD_PLUGIN_NAME,
             AuthPlugin::MysqlOldPassword => MYSQL_OLD_PASSWORD_PLUGIN_NAME,
             AuthPlugin::MysqlClearPassword => MYSQL_CLEAR_PASSWORD_PLUGIN_NAME,
             AuthPlugin::Ed25519 => ED25519_PLUGIN_NAME,
-            AuthPlugin::Parsec { .. } => PARSEC_PLUGIN_NAME,
+            AuthPlugin::Parsec => PARSEC_PLUGIN_NAME,
+            AuthPlugin::Sha256Password => SHA256_PASSWORD_PLUGIN_NAME,
             AuthPlugin::Other(name) => name,
         }
     }
 
     pub fn into_owned(self) -> AuthPlugin<'static> {
         match self {
-            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::CachingSha2Password => AuthPlugin::CachingSha2Password,
             AuthPlugin::MysqlNativePassword => AuthPlugin::MysqlNativePassword,
             AuthPlugin::MysqlOldPassword => AuthPlugin::MysqlOldPassword,
             AuthPlugin::MysqlClearPassword => AuthPlugin::MysqlClearPassword,
             AuthPlugin::Ed25519 => AuthPlugin::Ed25519,
             AuthPlugin::Parsec => AuthPlugin::Parsec,
+            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::Other(name) => AuthPlugin::Other(Cow::Owned(name.into_owned())),
         }
     }
 
     pub fn borrow(&self) -> AuthPlugin<'_> {
         match self {
-            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::CachingSha2Password => AuthPlugin::CachingSha2Password,
             AuthPlugin::MysqlNativePassword => AuthPlugin::MysqlNativePassword,
             AuthPlugin::MysqlOldPassword => AuthPlugin::MysqlOldPassword,
             AuthPlugin::MysqlClearPassword => AuthPlugin::MysqlClearPassword,
             AuthPlugin::Ed25519 => AuthPlugin::Ed25519,
             AuthPlugin::Parsec => AuthPlugin::Parsec,
+            AuthPlugin::Sha256Password => AuthPlugin::Sha256Password,
             AuthPlugin::Other(name) => AuthPlugin::Other(Cow::Borrowed(name.as_ref())),
         }
     }


### PR DESCRIPTION
Adds first-class support for MySQL's deprecated `sha256_password` authentication plugin.

The plugin is now implemented as a `ChallengeResponsePlugin` under `auth::plugins`, alongside the other authentication plugins:

- recognizes `sha256_password` as an `AuthPlugin` variant;
- sends the null-terminated password over TLS;
- requests the server RSA public key over non-TLS transports when no key is configured;
- encrypts the password using the plugin scramble and server public key;
- participates in the generic `AuthProc` dispatcher;
- documents the challenge preprocessing contract expected from drivers.

Validation:

- `cargo test --features test`
- 89 unit tests passed.
