### PR TITLE
`MYSQL_TYPE_NEWDATE` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ sha2 = "0.10"
 thiserror = "2"
 time = { version = "0.3", default-features = false, features = [
     "parsing",
+    "macros",
 ], optional = true }
 uuid = { version = "1" }
 saturating = "0.1"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -780,6 +780,7 @@ impl TryFrom<u8> for ColumnType {
             0x0b_u8 => Ok(ColumnType::MYSQL_TYPE_TIME),
             0x0c_u8 => Ok(ColumnType::MYSQL_TYPE_DATETIME),
             0x0d_u8 => Ok(ColumnType::MYSQL_TYPE_YEAR),
+            0x0e_u8 => Ok(ColumnType::MYSQL_TYPE_NEWDATE),
             0x0f_u8 => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
             0x10_u8 => Ok(ColumnType::MYSQL_TYPE_BIT),
             0x11_u8 => Ok(ColumnType::MYSQL_TYPE_TIMESTAMP2),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -442,6 +442,7 @@ impl Value {
                 .map(Double),
             ColumnType::MYSQL_TYPE_TIMESTAMP
             | ColumnType::MYSQL_TYPE_DATE
+            | ColumnType::MYSQL_TYPE_NEWDATE
             | ColumnType::MYSQL_TYPE_DATETIME => Self::deserialize_datetime(buf),
             ColumnType::MYSQL_TYPE_TIME => Self::deserialize_time(buf),
             ColumnType::MYSQL_TYPE_NULL => Ok(NULL),


### PR DESCRIPTION
Library now successfully decodes `MYSQL_TYPE_NEWDATE` and treats it similar to `MYSQL_TYPE_DATE`.
This fixes the issue with MariaDb 10.1.38 and probably some other legacy MariaDb versions.
See blackbeam/mysql_async#400